### PR TITLE
Prune any dangling images after `./pixel.js update`

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -276,6 +276,11 @@ function setupCli() {
 				'docker',
 				[ 'compose', ...getComposeOpts( [ 'build' ] ) ]
 			);
+			// Remove any dangling images.
+			await batchSpawn.spawn(
+				'docker',
+				[ 'image', 'prune', '-f' ]
+			);
 		} );
 
 	program


### PR DESCRIPTION
After updating the Dockerfiles, dangling images can remain after the
`./pixel.js update` which take up valuable space. Remove these by
running the `docker image prune` command.