### PR TITLE
Fix flaky scroll

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -1,3 +1,5 @@
+const fastForwardAnimations = require( './fastForwardAnimations' );
+
 /**
  * Runs after onReady event on all scenarios -- use for simulating interactions.
  *
@@ -36,4 +38,8 @@ module.exports = async ( page, scenario ) => {
 		await require( './search.js' )( page, hashtags );
 	}
 	// add more ready handlers here...
+
+	// Note: This should always be last.
+	// Fast forward through any css transitions/web animations that are happening.
+	await fastForwardAnimations( page );
 };


### PR DESCRIPTION
Sometimes the MediaWiki_Test_sticky_header_vector-2022_logged-in_scroll
test fails. I think what might be happening is the animation has
completed yet when the screenshot is taken. If this is the case, fast
forward through any animations.