### PR TITLE
Limit CI output

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,4 @@ jobs:
     - name: Run tests
       run: npm test
     - name: Run visual regression
-      shell: 'script -q -e -c "bash {0}"'
-      run: |
-        script -e -c "./pixel.js reference && ./pixel.js test"
+      run: "NONINTERACTIVE=true ./pixel.js reference && ./pixel.js test"


### PR DESCRIPTION
The github action ci reports are outputing a lot. This is an attempt to
see if we can make them output less.