### PR TITLE
Wait for browser idle period before taking a screenshot

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -1,4 +1,5 @@
 const fastForwardAnimations = require( './fastForwardAnimations' );
+const waitForIdle = require( './waitForIdle' );
 
 /**
  * Runs after onReady event on all scenarios -- use for simulating interactions.
@@ -39,7 +40,9 @@ module.exports = async ( page, scenario ) => {
 	}
 	// add more ready handlers here...
 
-	// Note: This should always be last.
+	// Note: These calls should always be last.
 	// Fast forward through any css transitions/web animations that are happening.
 	await fastForwardAnimations( page );
+	// Wait for the main thread to have an idle period.
+	await waitForIdle( page );
 };

--- a/src/engine-scripts/puppet/waitForIdle.js
+++ b/src/engine-scripts/puppet/waitForIdle.js
@@ -1,0 +1,21 @@
+/**
+ * Wait until the browser's main thread has an "idle" period [1] before
+ * continuing.
+ *
+ * [1] https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
+ *
+ * @param {import("puppeteer").Page} page
+ */
+async function waitForIdle( page ) {
+	return page.evaluate( async () => {
+		return new Promise( ( resolve ) => {
+			requestIdleCallback( () => {
+				resolve();
+			}, {
+				timeout: 500
+			} );
+		} );
+	} );
+}
+
+module.exports = waitForIdle;


### PR DESCRIPTION
Although not perfect (I've experienced the logo's network request
failing sometimes), by adding a requestIdleCallback, I was able to
execute 100 consecutive desktop tests successfully so I think it might
help increase the deterministic nature of the tests.