### PR TITLE
Fastforward

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -156,7 +156,6 @@ async function processCommand( type, opts ) {
 			overrideChangeId = overrideChangeId[ group ];
 			if ( overrideChangeId && type === 'reference' ) {
 				description = `(Fastforward of "${opts.branch}")`;
-				opts.branch = 'master';
 				opts.changeId = [ overrideChangeId ];
 				console.log( `Using ${opts.changeId} (this branch has been fastforwarded due to expected visual changes)` );
 			}

--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -79,6 +79,8 @@ class MwCheckout {
 			// Apply Gerrit patches, if any.
 			// @ts-ignore
 			if ( patchCommands[ repoId ] ) {
+				// Fastforward to master before applying commands since the commands will be a rebase
+				await this.#checkoutBranch( path, 'origin/master', repoId );
 				for ( const command of patchCommands[ repoId ] ) {
 					// Execute patch command.
 					await this.#batchSpawn.spawn(

--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -79,7 +79,7 @@ class MwCheckout {
 			// Apply Gerrit patches, if any.
 			// @ts-ignore
 			if ( patchCommands[ repoId ] ) {
-				// Fastforward to master before applying commands since the commands will be a rebase
+				// Fastforward to master before applying commands to support rebase command
 				await this.#checkoutBranch( path, 'origin/master', repoId );
 				for ( const command of patchCommands[ repoId ] ) {
 					// Execute patch command.


### PR DESCRIPTION
When a branch was fastforwarded it was causing all other branches to use master. This corrects that behaviour.