### PR TITLE
Checkout logic rebases onto the desired branch for overrides

### DIFF
--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -219,7 +219,7 @@ class MwCheckout {
 			}
 
 			commands[ change.project ] = commands[ change.project ] || [];
-			branch = branch ? branch : `origin/${change.branch}`;
+			branch = branch || `origin/${change.branch}`;
 			commands[ change.project ].unshift(
 				`
 				git -C "${path}" fetch origin ${change.revisions[ change.current_revision ].ref} && 

--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -187,7 +187,8 @@ class MwCheckout {
 	 *
 	 * @param {string[]} changeQueue
 	 * @param {Repos} repos
-	 * @param {string} branch rebase the change of a specific branch. If not defined uses change branch (master)
+	 * @param {string} branch rebase the change of a specific branch. If not defined
+	 *  uses change branch (master)
 	 * @return {Promise<PatchCommands>} patchCommands
 	 */
 	async #getPatchCommands( changeQueue, repos, branch = '' ) {


### PR DESCRIPTION
Overrides were being rebased against the master branch rather than
the current release meaning we were missing a few regressions.

Based on how this experiment has gone, I'm not sure it's a good
idea to use the overrides going forward because of this I'm only
using it to workaround the QuickSurveys EventLogging dependency