### PR TITLE
Add test cases for collapsed TOC

### DIFF
--- a/configDesktop.js
+++ b/configDesktop.js
@@ -58,6 +58,25 @@ const tests = [
 		path: '/wiki/Special:BlankPage'
 	},
 	{
+		label: 'Test (#vector-2022, #sidebar-closed, #collapsed-toc-closed)',
+		path: '/wiki/Test',
+		selectors: [ 'viewport' ],
+		// Limit to large viewports to minimize duplication
+		viewports: [
+			VIEWPORT_DESKTOP, VIEWPORT_DESKTOP_WIDE
+		]
+	},
+	{
+		label: 'Test (#vector-2022, #sidebar-closed, #collapsed-toc-open)',
+		path: '/wiki/Test',
+		selectors: [ 'viewport' ]
+	},
+	{
+		label: 'Test (#vector-2022, #sidebar-open, #collapsed-toc-open)',
+		path: '/wiki/Test',
+		selectors: [ 'viewport' ]
+	},
+	{
 		label: 'Special:BlankPage (#vector-2022, #userMenu-open)',
 		path: '/wiki/Special:BlankPage'
 	},
@@ -89,6 +108,24 @@ const tests = [
 		label: 'Test sticky header (#vector-2022, #logged-in, #scroll)',
 		path: '/wiki/Test',
 		selectors: [ 'viewport' ]
+	},
+	{
+		label: 'Test sticky header (#vector-2022, #logged-in, #scroll, #collapsed-toc-closed)',
+		path: '/wiki/Test',
+		selectors: [ 'viewport' ],
+		// Limit to viewports where the sticky header is visible
+		viewports: [
+			VIEWPORT_DESKTOP, VIEWPORT_DESKTOP_WIDE
+		]
+	},
+	{
+		label: 'Test sticky header (#vector-2022, #logged-in, #scroll, #collapsed-toc-open)',
+		path: '/wiki/Test',
+		selectors: [ 'viewport' ],
+		// Limit to viewports where the sticky header is visible
+		viewports: [
+			VIEWPORT_DESKTOP, VIEWPORT_DESKTOP_WIDE
+		]
 	},
 	{
 		label: 'Test?action=History (#vector-2022)',

--- a/src/engine-scripts/puppet/collapsedTocState.js
+++ b/src/engine-scripts/puppet/collapsedTocState.js
@@ -1,0 +1,27 @@
+const menuState = require( './menuState' );
+
+/**
+ * Open or close Vector-2022's collapsible TOC.
+ *
+ * @param {import('puppeteer').Page} page
+ * @param {string[]} hashtags
+ */
+module.exports = async ( page, hashtags ) => {
+	const isOpen = hashtags.includes( '#collapsed-toc-open' );
+	const isClosed = hashtags.includes( '#collapsed-toc-closed' );
+	const isStickyHeader = hashtags.includes( '#scroll' ) && hashtags.includes( '#logged-in' );
+
+	if ( !isOpen && !isClosed ) {
+		return;
+	}
+
+	const collapseTocButton = '.vector-toc-collapse-button';
+	await page.waitForSelector( collapseTocButton );
+	await page.evaluate( ( selector ) => {
+		const btn = document.querySelector( selector );
+		btn.click();
+	}, collapseTocButton );
+
+	const tocButtonSelector = isStickyHeader ? '#p-sticky-header-toc-checkbox' : '#vector-toc-collapsed-button';
+	await menuState( page, tocButtonSelector, isClosed );
+};

--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -20,6 +20,7 @@ module.exports = async ( page, scenario ) => {
 	if ( hashtags.includes( '#vector-2022' ) ) {
 		await require( './sidebarState' )( page, hashtags );
 		await require( './userMenuState' )( page, hashtags );
+		await require( './collapsedTocState' )( page, hashtags );
 	}
 
 	// These only apply to Minerva


### PR DESCRIPTION
### Summary
- Add collapsedTocState.js to handle #collapsed-toc-open and #collapsed-toc-closed tags
- Add tests for collapsed TOC in the page title, open and closed (includes variant with sidebar open)
- Add tests for collapsed TOC in the sticky header, open and closed