### PR TITLE
Make desktop group failures fail CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,5 +30,3 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         script -e -c "./pixel.js reference && ./pixel.js test"
-        script -e -c "./pixel.js reference -g echo && ./pixel.js test -g echo"
-        script -e -c "./pixel.js reference -g mobile && ./pixel.js test -g mobile"


### PR DESCRIPTION
Desktop tests were previously failing in CI [1] which suggests flaky tests, but because other test groups ran and succeeded, CI unfortunately reported everything passing.

This commit changes CI to only run the desktop group (which already takes long enough) and any failure should now cause CI to fail.

[1] https://github.com/wikimedia/pixel/actions/runs/3018870159/jobs/4854233371