### PR TITLE
Wait for network to idle before taking a screenshot

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -41,6 +41,8 @@ module.exports = async ( page, scenario ) => {
 	}
 	// add more ready handlers here...
 
+	// Wait for any images to finish loading.
+	await page.waitForNetworkIdle();
 	// Note: These calls should always be last.
 	// Fast forward through any css transitions/web animations that are happening.
 	await fastForwardAnimations( page );


### PR DESCRIPTION
I have been experiencing consistent screnshots of the sticky header and other elements not having their images loaded yet on my local machine. Waiting for the network to idle seems to stop this from happening.