### PR TITLE
Remove bolding from TOC (again)

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -59,7 +59,7 @@ module.exports = async ( page, scenario ) => {
 			'.sidebar-toc-list-item-active'
 		).forEach( ( node ) => {
 			node.classList.remove(
-				'sidebar-toc-list-item-active'
+				'sidebar-toc-list-item-active', 'sidebar-toc-level-1-active'
 			);
 		} );
 		return true;


### PR DESCRIPTION
The selector used for bolding was changed in
https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/833458 .

As a result, lots of false positives are showing up on https://pixel.wmcloud.org/reports/desktop/index.html

This commit updates the selector used to make the TOC bold.