### PR TITLE
Fix "ENGINE ERROR: Node is either not clickable or not an HTMLElement…

### DIFF
--- a/src/engine-scripts/puppet/search.js
+++ b/src/engine-scripts/puppet/search.js
@@ -34,6 +34,7 @@ module.exports = async ( page, hashtags ) => {
 	const button = await page.waitForSelector( selectorSearchToggle, {
 		visible: true
 	} );
+	await fastForwardAnimations( page );
 	await button.click();
 	// Focus the server side rendered search to trigger the loading of Vue.
 	await page.focus( selectorSearchInput );


### PR DESCRIPTION
Attempts to fix https://phabricator.wikimedia.org/T318260
    
I think this error is happening because Puppeteer is checking if the element is
within the viewport before it does the click. If it's not within the viewport,
puppeteer will throw this error [1].
    
The search toggle is not within the viewport because the animation hasn't
finished so fast forward that before clicking.
    
[1] https://github.com/puppeteer/puppeteer/blob/31e7b608d54dfeac8045cbc136ddf732f75e49d6/src/common/ElementHandle.ts#L538
