### PR TITLE
Fix Pixel hanging on MacBook Pro M1 by updating backstop/puppeteer/ch…

### DIFF
--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -1,4 +1,4 @@
-FROM node:16.15.1
+FROM node:16.15.1-bullseye
 
 ARG BACKSTOPJS_VERSION
 

--- a/README.md
+++ b/README.md
@@ -227,14 +227,6 @@ can be rebuilt) and then `./pixel.js reference` to rebuild everything
 4) Check that your extension or skin is usable at `localhost:3000`
 5) Commit these changes and open a pull request in this repo with these changes
 
-## Known Issues
-
-* Pixel has only been tested on machines running on `x86_64` chips. It does not
-currently work with `arm64` (e.g. MacBooks with M1 or M2 chips). Please follow
-https://github.com/garris/BackstopJS/issues/1300 and
-[T311573](https://phabricator.wikimedia.org/T311573) for more information.
-
-
-## New Issues
+## Issues
 
 Please file all bugs, requests, and issues on the [web team's visual regression phabricator board](https://phabricator.wikimedia.org/project/board/5933/)

--- a/configDesktop.js
+++ b/configDesktop.js
@@ -215,7 +215,7 @@ module.exports = {
 			'--no-sandbox'
 		]
 	},
-	asyncCaptureLimit: 5,
+	asyncCaptureLimit: 10,
 	asyncCompareLimit: 50,
 	debug: false,
 	debugWindow: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,13 @@ services:
       timeout: 5s
       retries: 20
   visual-regression:
+    init: true
     network_mode: host
     build:
       context: .
       dockerfile: Dockerfile.visual-regression
       args:
-        - BACKSTOPJS_VERSION=6.0.4
+        - BACKSTOPJS_VERSION=6.1.1
     working_dir: /pixel
     env_file:
       - .env

--- a/pixel.js
+++ b/pixel.js
@@ -295,6 +295,11 @@ function setupCli() {
 				'git',
 				[ '-C', __dirname, 'pull', 'origin', 'main' ]
 			);
+			// Install npm dependencies.
+			await batchSpawn.spawn(
+				'npm',
+				[ 'i' ]
+			);
 			// Stops and removes Docker containers, networks, and volumes.
 			await batchSpawn.spawn(
 				'docker',


### PR DESCRIPTION
…romium version

This attempts to fix https://phabricator.wikimedia.org/T318445 where Pixel would frequently hang on MacBook Pro m1 machines

I think the cause of this was that we were using chromium for debian buster which was only downloading chromium version 89 (the latest chromium version is > 100) which is only compatible with puppeteer 6 (we were using puppeteer 12) [1].

This commit updates the dockerfile to use debian bullseye which will currently use Chromium 105 [2] and updates to backstop to backstop 6.1.1 which uses puppeteer 15.5.0.

With these updates, this issue seems fixed!

Additionally:

* Add `init: true` to docker compose visual regression service which gets rid of zombie processes

* Increase asyncCaptureLimit from 5 to 10 which speeds up the tests by 20 seconds on my machine.

[1] https://github.com/puppeteer/puppeteer/blob/ddc567a4b6b94fb888a01521e5f36a9efc5ebf51/website/versioned_docs/version-18.0.5/chromium-support.md#chromium-support