### PR TITLE
Update mediawiki docker images to match what is in core

### DIFF
--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -1,4 +1,4 @@
-FROM docker-registry.wikimedia.org/dev/buster-php72-fpm:2.0.0-s1
+FROM docker-registry.wikimedia.org/dev/buster-php74-fpm:1.0.0-s3
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
 	&& apt-get install -y nodejs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       database:
         condition: service_healthy
   mediawiki-web:
-    image: docker-registry.wikimedia.org/dev/buster-apache2:1.0.0-s1
+    image: docker-registry.wikimedia.org/dev/buster-apache2:2.0.0-s1
     ports:
       - "${PIXEL_MW_DOCKER_PORT}:8080"
     env_file:


### PR DESCRIPTION
This fixes a couple errors that are related to pixel using php 7.2 instead of 7.4.