### PR TITLE
Add growth experiments extension and test

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -2,7 +2,7 @@ FROM mariadb:10.6.7
 
 COPY src/seedDb.sh /docker-entrypoint-initdb.d/
 
-ARG database="database_2022-07-08_15-15-12-0700(PDT).tar.gz"
+ARG database="database_2022-10-07_10-53-14-0600(MDT).tar.gz"
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -157,6 +157,7 @@ wfLoadExtension( 'RelatedArticles' );
 wfLoadExtension( 'SandboxLink' );
 wfLoadExtension( 'UniversalLanguageSelector' );
 wfLoadExtension( 'VisualEditor' );
+wfLoadExtension( 'GrowthExperiments' );
 
 // Make extended cookies (e.g. when logging in with "Keep me logged in" option)
 // last indefinitely.

--- a/README.md
+++ b/README.md
@@ -220,12 +220,20 @@ list of these.
 To add a skin or extension that isn't currently supported:
 
 1) Add it to the [repositories.json](repositories.json) file
-2) Make Pixel rebuild its code volume by running `./pixel.js clean` (this will
+2) Make Pixel rebuild its code volume by running `./pixel.js clean`. This will
 destroy every container, image, volume, network associated with Pixel so they
-can be rebuilt) and then `./pixel.js reference` to rebuild everything
-3) Configure it in [LocalSettings.php](LocalSettings.php)
+can be rebuilt. 
+3) Configure the extension or skin in [LocalSettings.php](LocalSettings.php).
+4) Run `./pixel.js reference` to rebuild everything. This will also run the
+`maintenance/update.php` script which executes any needed database schema
+changes. This will take awhile as Mediawiki core, extensions, and skins get
+downloaded again.
 4) Check that your extension or skin is usable at `localhost:3000`
-5) Commit these changes and open a pull request in this repo with these changes
+5) If there were any database changes involved, you'll need to update the seed
+data that is shared amongst users of Pixel. To do this, please follow steps 3
+through 9 on the [https://github.com/wikimedia/pixel-seed-data](Pixel seed data)
+repo.
+6) Commit these changes and open a pull request in this repo with these changes
 
 ## Issues
 

--- a/configDesktop.js
+++ b/configDesktop.js
@@ -146,6 +146,11 @@ const tests = [
 		]
 	},
 	{
+		label: 'Special:Homepage (#vector-2022, #logged-in)',
+		path: '/wiki/Special:Homepage',
+		selectors: [ 'viewport' ]
+	},
+	{
 		label: 'Main_Page (#vector)',
 		delay: 1500,
 		path: '/wiki/Main_Page?useskin=vector'

--- a/repositories.json
+++ b/repositories.json
@@ -1,27 +1,21 @@
 {
-	"mediawiki/extensions/Echo": {
-		"path": "extensions/Echo"
-	},
-	"mediawiki/extensions/GlobalPreferences": {
-		"path": "extensions/GlobalPreferences"
-	},
-	"mediawiki/extensions/QuickSurveys": {
-		"path": "extensions/QuickSurveys"
-	},
-	"mediawiki/extensions/VisualEditor": {
-		"path": "extensions/VisualEditor"
+	"mediawiki/extensions/BetaFeatures": {
+		"path": "extensions/BetaFeatures"
 	},
 	"mediawiki/extensions/Cite": {
 		"path": "extensions/Cite"
 	},
-	"mediawiki/extensions/RelatedArticles": {
-		"path": "extensions/RelatedArticles"
-	},
-	"mediawiki/extensions/BetaFeatures": {
-		"path": "extensions/BetaFeatures"
+	"mediawiki/extensions/Echo": {
+		"path": "extensions/Echo"
 	},
 	"mediawiki/extensions/Gadgets": {
 		"path": "extensions/Gadgets"
+	},
+	"mediawiki/extensions/GlobalPreferences": {
+		"path": "extensions/GlobalPreferences"
+	},
+	"mediawiki/extensions/GrowthExperiments": {
+		"path": "extensions/GrowthExperiments"
 	},
 	"mediawiki/extensions/MobileFrontend": {
 		"path": "extensions/MobileFrontend"
@@ -32,17 +26,26 @@
 	"mediawiki/extensions/Popups": {
 		"path": "extensions/Popups"
 	},
+	"mediawiki/extensions/QuickSurveys": {
+		"path": "extensions/QuickSurveys"
+	},
+	"mediawiki/extensions/RelatedArticles": {
+		"path": "extensions/RelatedArticles"
+	},
 	"mediawiki/extensions/SandboxLink": {
 		"path": "extensions/SandboxLink"
 	},
 	"mediawiki/extensions/UniversalLanguageSelector": {
 		"path": "extensions/UniversalLanguageSelector"
 	},
+	"mediawiki/extensions/VisualEditor": {
+		"path": "extensions/VisualEditor"
+	},
+	"mediawiki/skins/CologneBlue": {
+		"path": "skins/CologneBlue"
+	},
 	"mediawiki/skins/MinervaNeue": {
 		"path": "skins/MinervaNeue"
-	},
-	"mediawiki/skins/Vector": {
-		"path": "skins/Vector"
 	},
 	"mediawiki/skins/Modern": {
 		"path": "skins/Modern"
@@ -50,11 +53,11 @@
 	"mediawiki/skins/MonoBook": {
 		"path": "skins/MonoBook"
 	},
+	"mediawiki/skins/Vector": {
+		"path": "skins/Vector"
+	},
 	"mediawiki/skins/Timeless": {
 		"path": "skins/Timeless"
-	},
-	"mediawiki/skins/CologneBlue": {
-		"path": "skins/CologneBlue"
 	},
 	"mediawiki/core": {
 		"path": "."


### PR DESCRIPTION
* Adds growth experiments extension to repositories.json. Also regorganizes it to be alphabetical order.

* Updates database seed file url

* Updates readme with clearer instructions on how to do this for extensions that require database changes (e.g. like growth experiments)

To test this change, please run `./pixel.js clean` prior to running `./pixel.js reference` so that the database image can be updated.

Bug: [T319480](https://phabricator.wikimedia.org/T319480)