### PR TITLE
Fix Protocol error (Runtime.callFunctionOn): Target closed.

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -16,7 +16,7 @@ module.exports = async ( page, scenario ) => {
 	await require( './jsReady' )( page, hashtags );
 
 	if ( hashtags.includes( '#scroll' ) ) {
-		require( './scroll.js' )( page );
+		await require( './scroll.js' )( page );
 	}
 
 	// These only apply to Vector 2022

--- a/src/engine-scripts/puppet/scroll.js
+++ b/src/engine-scripts/puppet/scroll.js
@@ -3,14 +3,4 @@ module.exports = async ( page ) => {
 		window.scrollBy( 0, window.innerHeight );
 		return true;
 	} );
-	// wait for bolding of active section or toc collapsed button
-	await page.waitForSelector( '.sidebar-toc-list-item-active, #vector-toc-collapsed-button', {
-		visible: true
-	} );
-
-	// Wait for the scroll to settle - as it has side effects on things like the
-	// table of contents bolding of sections.
-	// Forgive us Nick.
-	// eslint-disable-next-line no-restricted-properties
-	await page.waitForTimeout( 2500 );
 };


### PR DESCRIPTION
During the web-maintained test group, this error would surface on every `#scroll` test case. A closer inspection of the onReady.js revealed that we weren't actually waiting on the scroll promise to resolve which is what was causing the error.

* Also, remove the setTimeout and waitForSelector calls as it doesn't appear anything was waiting on those.

Bug: [T317665](https://phabricator.wikimedia.org/T317665)