### PR TITLE
Remove delay from legacy Vector tests and "mobile" viewport from desk…

### DIFF
--- a/configDesktop.js
+++ b/configDesktop.js
@@ -1,7 +1,6 @@
 const BASE_URL = process.env.PIXEL_MW_SERVER;
 const utils = require( './utils' );
 const {
-	VIEWPORT_PHONE,
 	VIEWPORT_TABLET,
 	VIEWPORT_DESKTOP,
 	VIEWPORT_DESKTOP_WIDE,
@@ -152,28 +151,23 @@ const tests = [
 	},
 	{
 		label: 'Main_Page (#vector)',
-		delay: 1500,
 		path: '/wiki/Main_Page?useskin=vector'
 	},
 	{
 		label: 'Test (#vector)',
-		delay: 1500,
 		path: '/wiki/Test?useskin=vector',
 		selectors: [ 'html' ]
 	},
 	{
 		label: 'Test?action=History (#vector)',
-		delay: 1500,
 		path: '/w/index.php?title=Test&action=history&useskin=vector'
 	},
 	{
 		label: 'Talk:Test (#vector)',
-		delay: 1500,
 		path: '/wiki/Talk:Test?useskin=vector'
 	},
 	{
 		label: 'Tree (#vector)',
-		delay: 1500,
 		path: '/wiki/Tree?useskin=vector'
 	}
 ];
@@ -208,7 +202,6 @@ const scenarios = tests.map( ( test ) => {
 module.exports = {
 	id: 'MediaWiki',
 	viewports: [
-		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
 		VIEWPORT_DESKTOP,
 		VIEWPORT_DESKTOP_WIDE,

--- a/configMobile.js
+++ b/configMobile.js
@@ -1,5 +1,6 @@
 const configDesktop = require( './configDesktop.js' );
 const utils = require( './utils' );
+const { VIEWPORT_PHONE } = require( './viewports.js' );
 
 const BASE_URL = process.env.PIXEL_MW_SERVER;
 const tests = [
@@ -59,5 +60,9 @@ const scenarios = tests.map( ( test ) => {
 
 module.exports = Object.assign( {}, configDesktop, {
 	scenarios,
-	paths: utils.makePaths( 'mobile' )
+	paths: utils.makePaths( 'mobile' ),
+	viewports: [
+		VIEWPORT_PHONE,
+		...configDesktop.viewports
+	]
 } );

--- a/src/engine-scripts/puppet/fastForwardAnimations.js
+++ b/src/engine-scripts/puppet/fastForwardAnimations.js
@@ -10,6 +10,9 @@
  */
 async function fastForwardAnimations( page ) {
 	return page.evaluate( async () => {
+		// Turn off jQuery animations.
+		// eslint-disable-next-line no-undef
+		$.fx.off = true;
 		// Adapted from https://github.com/microsoft/playwright/blob/0a401b2d86a39df85e57ad30bcec9ef81618abd0/packages/playwright-core/src/server/screenshotter.ts#L174
 		document.getAnimations().forEach( ( animation ) => {
 			if ( animation.playbackRate === 0 || !animation.effect ) {

--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -40,14 +40,14 @@ module.exports = async ( page, scenario ) => {
 		await require( './search.js' )( page, hashtags );
 	}
 	// add more ready handlers here...
+	// Note: These calls should always be last.
 
 	// Wait for any images to finish loading.
 	await page.waitForNetworkIdle();
-	// Note: These calls should always be last.
-	// Fast forward through any css transitions/web animations that are happening.
-	await fastForwardAnimations( page );
 	// Wait for the main thread to have an idle period.
 	await waitForIdle( page );
+	// Fast forward through any css transitions/web animations that are happening.
+	await fastForwardAnimations( page );
 
 	/**
 	 * Remove the .sidebar-toc-list-item-active class from the item in the toc


### PR DESCRIPTION
…top group

The legacy Vector tests currently wait 1.5 seconds before taking a screenshot so that the dancing tabs can settle. This can slow down the tests considerably. Instead of the delay, we can turn off jQuery animations with `jquery.fx.off`.

Additionally:

* Reorder the fastForwardAnimations call to be after waitForIdle as we always want that to be after any async calls.

* Remove the mobile viewport from the desktop group. The mobile group retains the mobile viewport width.

[1] https://api.jquery.com/jquery.fx.off/

Bug: [T320302](https://phabricator.wikimedia.org/T320302)