### PR TITLE
Update logo icon src

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -185,7 +185,7 @@ $wgLocalisationCacheConf = [
 
 # Show the enwiki logo.
 $wgLogos = [
-	'icon' => 'https://en.wikipedia.org/static/images/mobile/copyright/wikipedia.png',
+	'icon' => 'https://en.wikipedia.org/static/images/icons/wikipedia.png',
 	'tagline' => [
 		'src' => 'https://en.wikipedia.org/static/images/mobile/copyright/wikipedia-tagline-en.svg',
 		'width' => 117,


### PR DESCRIPTION
https://pixel.wmcloud.org/reports/desktop/index.html is showing the globe icon missing because the request results in a 403 response. Update the src to use the same src as prod.