### PR TITLE
Fix mobile test flakiness

### DIFF
--- a/configMobile.js
+++ b/configMobile.js
@@ -14,7 +14,7 @@ const tests = [
 	},
 	{
 		label: 'Test (#minerva #mobile #logged-in)',
-		path: '/wiki/Test?useskin=minerva&useformat=mobile'
+		path: '/wiki/Test'
 	},
 	{
 		label: 'Test (#minerva #mobile #mainmenu-open)',
@@ -52,7 +52,10 @@ const scenarios = tests.map( ( test ) => {
 	return utils.addFeatureFlagQueryStringsToScenario(
 		Object.assign( {
 			url: `${BASE_URL}${test.path}`,
-			selectors: [ 'viewport' ]
+			// Using 'html' instead of 'viewport' due to flakiness of toolbar's text
+			// color. This is likely caused by a bug in either backstopjs or
+			// puppeteer.
+			selectors: [ 'html' ]
 		}, test ),
 		flags
 	);


### PR DESCRIPTION
The mobile tests sometimes fail due to differences in color of the toolbar's text. After a lot of trial and error, I believe this is due to using the `viewport` selector which seems have a bug in either backstopjs or puppeteer. Replacing it with the 'html' selector seems to eliminate this issue.

Also:

* Remove extraneous query string from the `Test (#minerva #mobile #logged-in)` test.

Bug: T322438