### PR TITLE
Add logged-in legacy vector test

### DIFF
--- a/configDesktop.js
+++ b/configDesktop.js
@@ -169,6 +169,10 @@ const tests = [
 	{
 		label: 'Tree (#vector)',
 		path: '/wiki/Tree?useskin=vector'
+	},
+	{
+		label: 'Test (#vector, #logged-in)',
+		path: '/wiki/Test?useskin=vector'
 	}
 ];
 


### PR DESCRIPTION
We should probably have at least one logged-in test that covers legacy Vector to catch regressions like regressions to the personal menu.