### PR TITLE
Remove test images as part of `test` command

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -138,6 +138,14 @@ async function resetDb() {
 }
 
 /**
+ * @param {string} configFile name of config file.
+ */
+function removeTestFolder( configFile ) {
+	const config = require( `${__dirname}/${configFile}` );
+	fs.rmSync( `${__dirname}/${config.paths.bitmaps_test}`, { recursive: true, force: true } );
+}
+
+/**
  * @param {'test'|'reference'} type
  * @param {any} opts
  */
@@ -187,6 +195,14 @@ async function processCommand( type, opts ) {
 			'docker',
 			[ 'compose', ...getComposeOpts( [ 'exec', ...( process.env.NONINTERACTIVE ? [ '-T' ] : [] ), 'mediawiki', '/src/main.js', JSON.stringify( opts ) ] ) ]
 		);
+
+		// Remove test screenshots folder (if present) so that its size doesn't
+		// increase with each `test` run. BackstopJS automatically removes the
+		// reference folder when the `reference` command is run, but not the test
+		// folder when the `test` command is run.
+		if ( type === 'test' ) {
+			removeTestFolder( configFile );
+		}
 		// Execute Visual regression tests.
 		await batchSpawn.spawn(
 			'docker',


### PR DESCRIPTION
Each test group generates a folder where it stores its test screenshots. While pixel automatically removes the reference folder when running the ./pixel.js reference command, it doesn't remove the test folder when running the ./pixel.js test command. This can lead to that folder becoming extremely large since it grows with every execution of the test command. This commit removes that folder with each invocation of the `test` command.

Bug: T322867