### PR TITLE
Update toc sticky header checkbox selector

### DIFF
--- a/src/engine-scripts/puppet/collapsedTocState.js
+++ b/src/engine-scripts/puppet/collapsedTocState.js
@@ -22,6 +22,6 @@ module.exports = async ( page, hashtags ) => {
 		btn.click();
 	}, collapseTocButton );
 
-	const tocButtonSelector = isStickyHeader ? '#p-sticky-header-toc-checkbox' : '#vector-toc-collapsed-button';
+	const tocButtonSelector = isStickyHeader ? '#vector-sticky-header-toc-checkbox' : '#vector-toc-collapsed-button';
 	await menuState( page, tocButtonSelector, isClosed );
 };


### PR DESCRIPTION
Looks like this was changed in 845059 from p-sticky-header-toc-checkbox to vector-sticky-header-toc-checkbox.