### PR TITLE
Change collapseTocButton selector to be more selective

### DIFF
--- a/src/engine-scripts/puppet/collapsedTocState.js
+++ b/src/engine-scripts/puppet/collapsedTocState.js
@@ -16,7 +16,7 @@ module.exports = async ( page, hashtags ) => {
 	}
 
 	// vector-pinnable-header-toggle-button is used in VectorPageTools=1
-	const collapseTocButton = '.vector-toc-collapse-button,.vector-pinnable-header-toggle-button';
+	const collapseTocButton = '.vector-toc-collapse-button,.vector-toc-pinnable-header .vector-pinnable-header-unpin-button';
 	await page.waitForSelector( collapseTocButton );
 	await page.evaluate( ( selector ) => {
 		const btn = document.querySelector( selector );


### PR DESCRIPTION
With vectorpagetools feature enabled, this collapse button has changed from `.vector-toc-collapse-button` to `vector-toc-pinnable-header .vector-pinnable-header-unpin-button`. Because there are more than one `.vector-pinnable-header-toggle-button` buttons, we have to choose a more selective selector. The status quo is actually clicking the hidden "move to sidebar" button which actually unexpectedly but desirably collapses the TOC but we should be more explicit.  