### PR TITLE
Use production bundle of Vue

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -360,6 +360,9 @@ HTML;
 	$out->addHTML( $css );
 };
 
+// Use production bundle of Vue to silence noisy warnings in console.
+$wgVueDevelopmentMode = false;
+
 $wgVectorLanguageAlertInSidebar = [
 	"logged_in" => true,
 	"logged_out" => true


### PR DESCRIPTION
Running ./pixel.js test currently outputs a lot of Vue warnings because we are using the development bundle of Vue. Use the production bundle instead to mimic how it is in production and silence this noise.