### PR TITLE
Update the update script

### DIFF
--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -95,7 +95,7 @@ class MwCheckout {
 		// The final step is to run maintenance/update script to perform any
 		// database migrations.
 		await this.#batchSpawn.spawn(
-			'php maintenance/update.php --quick',
+			'php maintenance/run.php maintenance/update.php --quick',
 			[],
 			{ shell: true }
 		);

--- a/src/__tests__/MwCheckout.test.js
+++ b/src/__tests__/MwCheckout.test.js
@@ -49,7 +49,7 @@ describe( 'MwCheckout.js', () => {
 
 			await factory.mwCheckout.checkout( 'master', [ 'I8d3af86fdc3daf42441a93fc5b64ebcef37c5fb4' ] );
 
-			expect( factory.batchSpawn.spawn ).toHaveBeenLastCalledWith( 'php maintenance/update.php --quick', expect.anything(), expect.anything() );
+			expect( factory.batchSpawn.spawn ).toHaveBeenLastCalledWith( 'php maintenance/run.php maintenance/update.php --quick', expect.anything(), expect.anything() );
 		} );
 
 		it( 'throws an error when branch is not found', async () => {


### PR DESCRIPTION
MediaWiki 1.40 introduces a large banner with the message "Do not run maintenance scripts directly, use maintenance/run.php instead!" when trying to run maintenance/update.php. Instead, we need to run maintenance/run.php with the name of the script as the argument.