### PR TITLE
Add tests for Codex components via VueTest extension

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -159,6 +159,7 @@ wfLoadExtension( 'SandboxLink' );
 wfLoadExtension( 'UniversalLanguageSelector' );
 wfLoadExtension( 'VisualEditor' );
 wfLoadExtension( 'GrowthExperiments' );
+wfLoadExtension( 'VueTest' );
 
 // Make extended cookies (e.g. when logging in with "Keep me logged in" option)
 // last indefinitely.

--- a/configCodex.js
+++ b/configCodex.js
@@ -37,7 +37,8 @@ const scenarios = utils.makeScenariosForSkins(
 			label: 'cdx-' + component,
 			path: '/wiki/Special:VueTest/codex',
 			selectors: [ '.cdx-sandbox__content #cdx-' + component ],
-			misMatchThreshold: 1
+			requireSameDimensions: false,
+			misMatchThreshold: 5
 		};
 	} ),
 	// TODO: add interactive tests for Dialog, clearable Input, and maybe TypeaheadSearch

--- a/configCodex.js
+++ b/configCodex.js
@@ -37,8 +37,8 @@ const scenarios = utils.makeScenariosForSkins(
 			label: 'cdx-' + component,
 			path: '/wiki/Special:VueTest/codex',
 			selectors: [ '.cdx-sandbox__content #cdx-' + component ],
-			requireSameDimensions: false,
-			misMatchThreshold: 5
+			removeSelectors: [ '.cdx-sandbox__nav', `main > section:not(#cdx-${component}` ],
+			misMatchThreshold: 1
 		};
 	} ),
 	// TODO: add interactive tests for Dialog, clearable Input, and maybe TypeaheadSearch

--- a/configCodex.js
+++ b/configCodex.js
@@ -1,0 +1,69 @@
+const utils = require( './utils' );
+const {
+	VIEWPORT_PHONE,
+	VIEWPORT_TABLET,
+	VIEWPORT_DESKTOP
+} = require( './viewports' );
+
+// List of all components currently documented in the VueTest extension's Sandbox page.
+// Dialog is left out because all Dialog demos require interaction to test properly.
+// TODO: Add Link and ProgressBar once their demos are added to the codex-demos package.
+const components = [
+	'button',
+	'button-group',
+	'card',
+	'checkbox',
+	'combobox',
+	'icon',
+	'lookup',
+	'menu',
+	'menu-item',
+	'message',
+	'radio',
+	'search-input',
+	'select',
+	'tabs',
+	'text-input',
+	'thumbnail',
+	'toggle-button',
+	'toggle-button-group',
+	'toggle-switch',
+	'typeahead-search'
+];
+
+const scenarios = utils.makeScenariosForSkins(
+	components.map( ( component ) => {
+		return {
+			label: 'cdx-' + component,
+			path: '/wiki/Special:VueTest/codex',
+			selectors: [ '.cdx-sandbox__content #cdx-' + component ],
+			misMatchThreshold: 1
+		};
+	} ),
+	// TODO: add interactive tests for Dialog, clearable Input, and maybe TypeaheadSearch
+	[ 'vector-2022', 'minerva' ]
+);
+
+module.exports = {
+	id: 'MediaWiki',
+	viewports: [
+		VIEWPORT_PHONE,
+		VIEWPORT_TABLET,
+		VIEWPORT_DESKTOP
+	],
+	onBeforeScript: 'puppet/onBefore.js',
+	onReadyScript: 'puppet/onReady.js',
+	scenarios,
+	paths: utils.makePaths( 'codex' ),
+	report: [],
+	engine: 'puppeteer',
+	engineOptions: {
+		args: [
+			'--no-sandbox'
+		]
+	},
+	asyncCaptureLimit: 10,
+	asyncCompareLimit: 50,
+	debug: false,
+	debugWindow: false
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,5 +72,6 @@ services:
       - ./configCampaignEvents.js:/pixel/configCampaignEvents.js
       - ./configWebMaintained.js:/pixel/configWebMaintained.js
       - ./configMobile.js:/pixel/configMobile.js
+      - ./configCodex.js:/pixel/configCodex.js
       - ./src:/pixel/src
       - ./report:/pixel/report

--- a/pixel.js
+++ b/pixel.js
@@ -108,6 +108,8 @@ const getGroupConfig = ( groupName ) => {
 			return 'configMobile.js';
 		case 'campaign-events':
 			return 'configCampaignEvents.js';
+		case 'codex':
+			return 'configCodex.js';
 		default:
 			throw new Error( `Unknown test group: ${groupName}` );
 	}

--- a/repositories.json
+++ b/repositories.json
@@ -44,6 +44,9 @@
 	"mediawiki/extensions/VisualEditor": {
 		"path": "extensions/VisualEditor"
 	},
+	"mediawiki/extensions/VueTest": {
+		"path": "extensions/VueTest"
+	},
 	"mediawiki/skins/CologneBlue": {
 		"path": "skins/CologneBlue"
 	},


### PR DESCRIPTION
This patch introduces a new group of tests for Codex components. It tests the sandbox page provided by the VueTest extension, which contains a series of demos for each component. Each test targets a single component's demos.

Currently, all tests capture the initial state of the component. Some components, like Dialog, will require writing some interactivity into the tests to properly capture the component's features.

---

### Testing instructions

One of my goals for this addition is to limit its impact on the existing testing infrastructure and maintenance of this repo. As @nicholasray suggested, I created a separate config for the Codex tests, so they will only run when their group is included.

I noticed a lot of what seem like false positives when comparing the reference to existing patches in Codex. You can test out a couple yourself by doing the following:

- Take reference shots with `./pixel.js reference -g codex`. Note that this is based on the master branch of the VueTest extension, which at the time of writing this PR, is up to date with the main branch of Codex. That said, it does not update automatically when things are merged into Codex, there is a manual process for updating the VueTest extension
- Run a test against a patch that adds some CSS-only versions of components and refactors some markup/styles via `./pixel.js test -g codex -c Ie4c255ff26b466dc154bc7f4d36787fd5007a944` (see [patch](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/VueTest/+/879146)). You'll get a lot of failures, most of which seem to be false positives (I'm not sure why the checkboxes and radios are getting spaced further apart; maybe that's an actual finding)
- Run a test against a patch that changes a few icon and thumbnail styles via `./pixel.js test -g codex -c I565cbb340d4a894bd2846a74579e69fa6c6ec065` (see [patch](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/VueTest/+/879145)). There are fewer findings, and some of them are expected (all the ones related to Card, Thumbnail, Message, and TypeaheadSearch). 

### misMatchThreshold

Initially, I set a `misMatchThreshold` of 0.04 to match other tests in Pixel, and raising it to 1 did get rid of some of the noise. I wonder if some of this is related to the fact that you're testing a bunch of demos on the same page, and if something changes above a demo, that demo might look as if it has changed too, in the eyes of Backstop at least. I thought testing each `<section>` would mitigate this issue, but maybe it hasn't. I'm not exactly sure where to land on the threshold, or if we should focus on reformatting the VueTest page to be more amenable to visual regression testing. @nicholasray do you have any advice on how we could optimize the UI for VRT to avoid false positives? I'll throw a screenshot of part of the page at the end so you can get an idea of what I'm talking about (or if you're running Pixel locally you can go to Special:VueTest/codex).

### Noise and notifications

Also, will it be annoying for the maintainers of Pixel if there are regularly false positives and/or actual expected findings in the Codex tests? I think at least the latter will be more common for Codex than, say, the Web team's UIs. How disruptive will this be in terms of the live comparisons on https://pixel.wmcloud.org/? Do y'all get pinged when there are test failures? Could we set it up to ping the DST instead?

### Interactivity

There are a few things (the entire Dialog component and some features of a few others) that we can't test without adding some interaction into the tests. I'll plan on doing this in the coming weeks if possible, but it doesn't need to block this initial PR.

### Other blockers

As mentioned elsewhere, the VueTest extension lacks release branches, so we will need to fix that before this PR can be taken out of a WIP state and merged.