### PR TITLE
Remove scroll from scrollToc.js

### DIFF
--- a/src/engine-scripts/puppet/scrollToc.js
+++ b/src/engine-scripts/puppet/scrollToc.js
@@ -5,9 +5,5 @@ module.exports = async ( page ) => {
 		for ( const btn of tocToggleBtns ) {
 			btn.click();
 		}
-		tocElement.scrollBy( 0, tocElement.scrollHeight );
-		// Scroll up 30px from the bottom of the TOC to allow the scrollable indicator to show
-		tocElement.scrollBy( 0, -30 );
-		return true;
 	} );
 };


### PR DESCRIPTION
I noticed the scroll-toc test was failing because it looked like the browser hadn't finished painting the finished scroll state before taking the screenshot.

Wondering if we can remove the scroll though, as it seems the fade is applied even without scrolling.