### PR TITLE
Adding campaign events extension to pixel 

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -2,7 +2,7 @@ FROM mariadb:10.6.7
 
 COPY src/seedDb.sh /docker-entrypoint-initdb.d/
 
-ARG database="database_2023-01-11_12-42-02-0600(CST).tar.gz"
+ARG database="database_2023-01-27_13-42-07-0700(MST).tar.gz"
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -145,6 +145,7 @@ wfLoadSkin( 'Timeless' );
 # to LocalSettings.php. Check specific extension documentation for more details.
 # The following extensions were automatically enabled:
 wfLoadExtension( 'BetaFeatures' );
+wfLoadExtension( 'CampaignEvents' );
 wfLoadExtension( 'Cite' );
 wfLoadExtension( 'Echo' );
 wfLoadExtension( 'Gadgets' );

--- a/repositories.json
+++ b/repositories.json
@@ -2,6 +2,9 @@
 	"mediawiki/extensions/BetaFeatures": {
 		"path": "extensions/BetaFeatures"
 	},
+	"mediawiki/extensions/CampaignEvents": {
+		"path": "extensions/CampaignEvents"
+	},
 	"mediawiki/extensions/Cite": {
 		"path": "extensions/Cite"
 	},


### PR DESCRIPTION
Adding the Campaign Events extension to the pixel list of repositories.  The repo successfully clones into pixel and I am able to open the extension from local port 3000