### PR TITLE
Fix update script

### DIFF
--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -95,7 +95,7 @@ class MwCheckout {
 		// The final step is to run maintenance/update script to perform any
 		// database migrations.
 		await this.#batchSpawn.spawn(
-			'php maintenance/run.php maintenance/update.php --quick',
+			'php maintenance/run.php update.php --quick',
 			[],
 			{ shell: true }
 		);

--- a/src/__tests__/MwCheckout.test.js
+++ b/src/__tests__/MwCheckout.test.js
@@ -49,7 +49,7 @@ describe( 'MwCheckout.js', () => {
 
 			await factory.mwCheckout.checkout( 'master', [ 'I8d3af86fdc3daf42441a93fc5b64ebcef37c5fb4' ] );
 
-			expect( factory.batchSpawn.spawn ).toHaveBeenLastCalledWith( 'php maintenance/run.php maintenance/update.php --quick', expect.anything(), expect.anything() );
+			expect( factory.batchSpawn.spawn ).toHaveBeenLastCalledWith( 'php maintenance/run.php update.php --quick', expect.anything(), expect.anything() );
 		} );
 
 		it( 'throws an error when branch is not found', async () => {


### PR DESCRIPTION
The update script currently results in the following error:

"Script 'maintenance/update.php' not found (tried path '/var/www/html/w/maintenance/maintenance/update.php' and class 'maintenance/update\php')."

This commit updates the update script to avoid this error.