### PR TITLE
Temporarily fix the flaky scrolling tests

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -17,6 +17,8 @@ module.exports = async ( page, scenario ) => {
 
 	if ( hashtags.includes( '#scroll' ) ) {
 		await require( './scroll.js' )( page );
+		// eslint-disable-next-line no-restricted-properties
+		await page.waitForTimeout( 500 );
 	}
 
 	// These only apply to Vector 2022


### PR DESCRIPTION
The merge of 885878 exposed some flakiness involving scrolling where we're not waiting long enough after scrolling. Temporarily use waitForTimeout and I'll look into swapping it for a better solution tomorrow.