### PR TITLE
Temporarily disable GrowthExperiments extension

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -158,7 +158,7 @@ wfLoadExtension( 'RelatedArticles' );
 wfLoadExtension( 'SandboxLink' );
 wfLoadExtension( 'UniversalLanguageSelector' );
 wfLoadExtension( 'VisualEditor' );
-wfLoadExtension( 'GrowthExperiments' );
+// wfLoadExtension( 'GrowthExperiments' );
 wfLoadExtension( 'VueTest' );
 
 // Make extended cookies (e.g. when logging in with "Keep me logged in" option)


### PR DESCRIPTION
It is causing a "Wikimedia\Services\NoSuchServiceException: No such service: EventBus.EventBusFactory" error. I will enable when I determine how to fix it. For now, it is making pixel unusable.