### PR TITLE
Remove old class removal code for the TOC bolding

### DIFF
--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -61,21 +61,4 @@ module.exports = async ( page, scenario ) => {
 	await waitForIdle( page );
 	// Fast forward through any css transitions/web animations that are happening.
 	await fastForwardAnimations( page );
-
-	/**
-	 * Remove the .sidebar-toc-list-item-active, .vector-toc-list-item-active
-	 * class from the item in the toc What is focused is variable, so can lead to
-	 * false positives in pixel.  Knowing it exists is enough to know it is
-	 * working.
-	 */
-	await page.evaluate( () => {
-		document.querySelectorAll(
-			'.sidebar-toc-list-item-active, .vector-toc-list-item-active'
-		).forEach( ( node ) => {
-			node.classList.remove(
-				'sidebar-toc-list-item-active', 'vector-toc-list-item-active'
-			);
-		} );
-		return true;
-	} );
 };


### PR DESCRIPTION
The `.sidebar-toc-list-item-active` class isn't used anymore, and the TOC bolding seems to not be flaky anymore, so this seems to be extraneous code.