### PR TITLE
Replace waitForTimeout call in scroll conditional with deferToFrame

### DIFF
--- a/src/engine-scripts/puppet/deferToFrame.js
+++ b/src/engine-scripts/puppet/deferToFrame.js
@@ -1,0 +1,32 @@
+/**
+ * Helper method that resolves a Promise after the browser has performed a
+ * specified number of repaints.
+ *
+ * Uses `requestAnimationFrame` under the hood to determine the next repaint.
+ *
+ * @param {import("puppeteer").Page} page
+ * @param {number} frameCount The number of frames to wait before resolving the
+ * promise.
+ * @return {Promise}
+ */
+async function deferToFrame( page, frameCount ) {
+	return page.evaluate( async ( count ) => {
+		const f = async () => {
+			return new Promise( ( resolve ) => {
+				if ( count === 0 ) {
+					resolve();
+					return;
+				}
+
+				requestAnimationFrame( () => {
+					count -= 1;
+					resolve( f() );
+				} );
+			} );
+		};
+
+		return f();
+	}, frameCount );
+}
+
+module.exports = deferToFrame;

--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -1,3 +1,4 @@
+const deferToFrame = require( './deferToFrame' );
 const fastForwardAnimations = require( './fastForwardAnimations' );
 const waitForIdle = require( './waitForIdle' );
 
@@ -44,8 +45,10 @@ module.exports = async ( page, scenario ) => {
 
 	if ( hashtags.includes( '#scroll' ) ) {
 		await require( './scroll.js' )( page );
-		// eslint-disable-next-line no-restricted-properties
-		await page.waitForTimeout( 500 );
+		// Anecdotally, browsers can take up to 3 repaints before painting the new
+		// scroll position.
+		await deferToFrame( page, 3 );
+
 	}
 
 	if ( hashtags.includes( '#search-focus' ) ) {


### PR DESCRIPTION
deferToFrame is slightly better since it is tied to the repaints the browser makes instead of a hard-coded timeout value.