### PR TITLE
Use specific Chromium arm binary

### DIFF
--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -9,13 +9,21 @@ ENV \
 RUN apt-get update && \
 	apt-get install -y git sudo software-properties-common
 
+# Find links to Chromium arm64 binaries here: http://snapshot.debian.org/binary/chromium/
+ENV CHROMIUM_ARM_URL http://snapshot.debian.org/archive/debian-security/20220902T180902Z/pool/updates/main/c/chromium/
+ENV CHROMIUM_ARM_BINARY chromium_105.0.5195.52-1~deb11u1_arm64.deb
+ENV CHROMIUM_ARM_COMMON_BINARY chromium-common_105.0.5195.52-1~deb11u1_arm64.deb
+
 RUN /bin/bash -c 'set -ex && \
     ARCH=`uname -m` && \
     if [ "$ARCH" == "x86_64" ]; then \
        sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}; \
     else \
        sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION} && \
-       apt-get -qqy update && apt-get -qqy --no-install-recommends install chromium && \
+       wget "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_COMMON_BINARY}" \
+            "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_BINARY}" && \
+       apt install -y "./${CHROMIUM_ARM_COMMON_BINARY}" \
+                      "./${CHROMIUM_ARM_BINARY}" && \
        sudo test -f /usr/bin/chromium && sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser && sudo ln -s /usr/bin/chromium /usr/bin/chrome; \
     fi'
 


### PR DESCRIPTION
Closer to version expected by version of Puppeteer used by BackstopJS

Bug: T332353