### PR TITLE
Add a11y testing to pixel

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 report
+report-a11y
 package-lock.json
 coverage
 context.json

--- a/Dockerfile.a11y-regression
+++ b/Dockerfile.a11y-regression
@@ -9,23 +9,28 @@ ENV \
 RUN apt-get update && \
 	apt-get install -y git sudo software-properties-common
 
-# Find links to Chromium arm64 binaries here: http://snapshot.debian.org/binary/chromium/
-ENV CHROMIUM_ARM_URL http://snapshot.debian.org/archive/debian-security/20220902T180902Z/pool/updates/main/c/chromium/
-ENV CHROMIUM_ARM_BINARY chromium_105.0.5195.52-1~deb11u1_arm64.deb
-ENV CHROMIUM_ARM_COMMON_BINARY chromium-common_105.0.5195.52-1~deb11u1_arm64.deb
-
-RUN /bin/bash -c 'set -ex && \
+RUN set -ex && \
+    DEBIAN_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f2 | tr -d '"') && \
+    export DEBIAN_VERSION=$DEBIAN_VERSION && \
     ARCH=`uname -m` && \
-    if [ "$ARCH" == "x86_64" ]; then \
+    if [ "$ARCH" = "x86_64" ]; then \
        sudo npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION}; \
     else \
-       sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION} && \
-       wget "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_COMMON_BINARY}" \
-            "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_BINARY}" && \
-       apt install -y "./${CHROMIUM_ARM_COMMON_BINARY}" \
-                      "./${CHROMIUM_ARM_BINARY}" && \
+       sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION} && puppeteer-chromium-version-finder@^1.0.1 chromium-version-deb-finder@^2.0.1 && \
+       NODE_PATH="$(npm root -g):$(npm root -g)/backstopjs/node_modules" node -e " \
+          const versionFinder = require('puppeteer-chromium-version-finder'); \
+          const debFinder = require('chromium-version-deb-finder'); \
+          (async () => { \
+            const version = await versionFinder.getPuppeteerChromiumVersion(); \
+            const debUrls = await debFinder.getDebUrlsForVersionAndArch(version.MAJOR, version.MINOR, process.env.DEBIAN_VERSION, 'arm64'); \
+            console.log(debUrls.join('\n')); \
+          })(); \
+       " | \
+       xargs -I % sh -c 'set -x; echo "Downloading: %"; wget -c -t 10 -w 10 -T 120 %; echo "Downloaded: %"' && \
+       apt install -y ./*.deb && \
+       rm -f ./*.deb && \
        sudo test -f /usr/bin/chromium && sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser && sudo ln -s /usr/bin/chromium /usr/bin/chrome; \
-    fi'
+    fi
 
 RUN sudo npm install -g mustache
 

--- a/Dockerfile.a11y-regression
+++ b/Dockerfile.a11y-regression
@@ -1,0 +1,53 @@
+FROM node:16.15.1-bullseye
+
+ARG PA11Y_VERSION
+
+ENV \
+	PA11Y_VERSION=$PA11Y_VERSION
+
+# Base packages
+RUN apt-get update && \
+	apt-get install -y git sudo software-properties-common
+
+# Find links to Chromium arm64 binaries here: http://snapshot.debian.org/binary/chromium/
+ENV CHROMIUM_ARM_URL http://snapshot.debian.org/archive/debian-security/20220902T180902Z/pool/updates/main/c/chromium/
+ENV CHROMIUM_ARM_BINARY chromium_105.0.5195.52-1~deb11u1_arm64.deb
+ENV CHROMIUM_ARM_COMMON_BINARY chromium-common_105.0.5195.52-1~deb11u1_arm64.deb
+
+RUN /bin/bash -c 'set -ex && \
+    ARCH=`uname -m` && \
+    if [ "$ARCH" == "x86_64" ]; then \
+       sudo npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION}; \
+    else \
+       sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION} && \
+       wget "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_COMMON_BINARY}" \
+            "${CHROMIUM_ARM_URL}${CHROMIUM_ARM_BINARY}" && \
+       apt install -y "./${CHROMIUM_ARM_COMMON_BINARY}" \
+                      "./${CHROMIUM_ARM_BINARY}" && \
+       sudo test -f /usr/bin/chromium && sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser && sudo ln -s /usr/bin/chromium /usr/bin/chrome; \
+    fi'
+
+RUN sudo npm install -g mustache
+
+RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
+RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
+
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
+    libxshmfence-dev \
+    libfontconfig \
+    libfreetype6 \
+    xfonts-cyrillic \
+    xfonts-scalable \
+    fonts-liberation \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+    libgbm-dev \
+    gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -qyy clean
+
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+#ENTRYPOINT ["tail", "-f", "/dev/null"]
+ENTRYPOINT ["node", "src/a11y/runA11yTests.js"]

--- a/configDesktopA11y.js
+++ b/configDesktopA11y.js
@@ -16,10 +16,10 @@ const testDefaults = {
 	includeWarnings: true,
 	includeNotices: true,
 	ignore: [
+		// Prevent axe-core from flagging all TOC links as incorrect color contrast
 		'color-contrast',
 		'WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID'
 	],
-	hideElements: '#bodyContent, #siteNotice',
 	chromeLaunchConfig: {
 		headless: true,
 		args: [

--- a/configDesktopA11y.js
+++ b/configDesktopA11y.js
@@ -1,0 +1,47 @@
+// @ts-nocheck
+const utils = require( './utils' );
+
+const NAMESPACE = 'desktop';
+const BASE_URL = process.env.PIXEL_MW_SERVER;
+
+const testDefaults = {
+	viewport: {
+		width: 1200,
+		height: 1080
+	},
+	runners: [
+		'axe',
+		'htmlcs'
+	],
+	includeWarnings: true,
+	includeNotices: true,
+	ignore: [
+		'color-contrast',
+		'WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID'
+	],
+	hideElements: '#bodyContent, #siteNotice',
+	chromeLaunchConfig: {
+		headless: true,
+		args: [
+			'--no-sandbox',
+			'--disable-setuid-sandbox'
+		]
+	}
+};
+
+module.exports = {
+	namespace: NAMESPACE,
+	paths: utils.makeA11yPaths( NAMESPACE ),
+	tests: [
+		{
+			name: 'default',
+			url: BASE_URL + '/wiki/Test',
+			...testDefaults
+		},
+		{
+			name: 'logged_in',
+			url: BASE_URL + '/wiki/Test',
+			...testDefaults
+		}
+	]
+};

--- a/configDesktopA11y.js
+++ b/configDesktopA11y.js
@@ -18,7 +18,8 @@ const testDefaults = {
 	ignore: [
 		// Prevent axe-core from flagging all TOC links as incorrect color contrast
 		'color-contrast',
-		'WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID'
+		// Prevent contrast ratio error on absolutely positioned elements
+		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs'
 	],
 	chromeLaunchConfig: {
 		headless: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,3 +75,21 @@ services:
       - ./configCodex.js:/pixel/configCodex.js
       - ./src:/pixel/src
       - ./report:/pixel/report
+  a11y-regression:
+    init: true
+    network_mode: host
+    build:
+      context: .
+      dockerfile: Dockerfile.a11y-regression
+      args:
+        - PA11Y_VERSION=6.2.3
+    working_dir: /pixel
+    env_file:
+      - .env
+    volumes:
+      - ./context.json:/pixel/context.json
+      - ./viewports.js:/pixel/viewports.js
+      - ./utils.js:/pixel/utils.js
+      - ./configDesktopA11y.js:/pixel/configDesktopA11y.js
+      - ./src:/pixel/src
+      - ./report-a11y:/pixel/report-a11y

--- a/pixel.js
+++ b/pixel.js
@@ -349,6 +349,10 @@ function setupCli() {
 		'-a, --a11y',
 		'Run automated a11y tests in addition to visual regression.'
 	] );
+	const logResultsOpt = /** @type {const} */ ( [
+		'-l, --logResults',
+		'Log accessibility results to statsv.'
+	] );
 	const branchOpt = /** @type {const} */ ( [
 		'-b, --branch <name-of-branch>',
 		`Name of branch. Can be "${MAIN_BRANCH}" or a release branch (e.g. "origin/wmf/1.37.0-wmf.19"). Use "${LATEST_RELEASE_BRANCH}" to use the latest wmf release branch.`,
@@ -387,6 +391,7 @@ function setupCli() {
 		.description( 'Create reference (baseline) screenshots and delete the old reference screenshots.' )
 		.requiredOption( ...branchOpt )
 		.option( ...a11yOpt )
+		.option( ...logResultsOpt )
 		.option( ...changeIdOpt )
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
@@ -399,6 +404,7 @@ function setupCli() {
 		.description( 'Create test screenshots and compare them against the reference screenshots.' )
 		.requiredOption( ...branchOpt )
 		.option( ...a11yOpt )
+		.option( ...logResultsOpt )
 		.option( ...changeIdOpt )
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )

--- a/report-a11y/.gitignore
+++ b/report-a11y/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything except this file
+*
+!.gitignore

--- a/src/a11y/reporter/Results.mustache
+++ b/src/a11y/reporter/Results.mustache
@@ -1,21 +1,11 @@
-<h3>Overview</h3>
-
-<nav class="counts" aria-label="Issue counts">
-	{{#totalErrorCount}}<a href="#error-{{name}}" class="count error">{{.}} error(s)</a>{{/totalErrorCount}}
-	{{#totalWarningCount}}<a href="#warning-{{name}}" class="count warning">{{.}} warning(s)</a>{{/totalWarningCount}}
-	{{#totalNoticeCount}}<a href="#notice-{{name}}" class="count notice">{{.}} notice(s)</a>{{/totalNoticeCount}}
-</nav>
-
-{{#data}}
 <div id="{{type}}-{{name}}" class="container">
-	<h3>{{typeLabel}}</h3>
+	<h3>{{typeLabel}} ({{typeCount}})</h3>
 	{{#codes}}
 	<div class="message {{type}}">
 		<h4>{{message}}</h4>
-		<p><b>Rule:</b> {{runner}}, {{code}}</p>
+		<p class="rule"><b>Rule:</b> {{runner}}, {{code}}</p>
 		{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
-		<hr>
-		<details>
+		<details class="details">
 			<summary>
 				{{issueCount}} issue(s):
 			</summary>
@@ -30,4 +20,3 @@
 	</div>
 	{{/codes}}
 </div>
-{{/data}}

--- a/src/a11y/reporter/Results.mustache
+++ b/src/a11y/reporter/Results.mustache
@@ -1,0 +1,33 @@
+<h3>Overview</h3>
+
+<nav class="counts" aria-label="Issue counts">
+	{{#totalErrorCount}}<a href="#error-{{name}}" class="count error">{{.}} error(s)</a>{{/totalErrorCount}}
+	{{#totalWarningCount}}<a href="#warning-{{name}}" class="count warning">{{.}} warning(s)</a>{{/totalWarningCount}}
+	{{#totalNoticeCount}}<a href="#notice-{{name}}" class="count notice">{{.}} notice(s)</a>{{/totalNoticeCount}}
+</nav>
+
+{{#data}}
+<div id="{{type}}-{{name}}" class="container">
+	<h3>{{typeLabel}}</h3>
+	{{#codes}}
+	<div class="message {{type}}">
+		<h4>{{message}}</h4>
+		<p><b>Rule:</b> {{runner}}, {{code}}</p>
+		{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
+		<hr>
+		<details>
+			<summary>
+				{{issueCount}} issue(s):
+			</summary>
+			<ul class="issues-list">
+				{{#issues}}
+				<li class="issue">
+					<pre>{{selector}}<hr>{{context}}</pre>
+				</li>
+				{{/issues}}
+			</ul>
+		</details>
+	</div>
+	{{/codes}}
+</div>
+{{/data}}

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+	<meta charset="utf-8"/>
+	<title>Accessibility Report For "{{pageUrl}}" ({{date}})</title>
+
+	<style>
+
+		html, body {
+			margin: 0;
+			padding: 0;
+			background-color: #fff;
+			font-family: Arial, Helvetica, sans-serif;
+			font-size: 16px;
+			line-height: 22px;
+			color: #333;
+		}
+		li {
+			margin-bottom: 15px;
+		}
+		pre {
+			white-space: pre-wrap;
+			overflow: auto;
+		}
+
+		.page {
+			max-width: 800px;
+			margin: 0 auto;
+			padding: 25px;
+		}
+
+		.counts {
+			margin-top: 30px;
+			font-size: 20px;
+		}
+		.count {
+			display: inline-block;
+			padding: 5px;
+			border-radius: 5px;
+			border: 1px solid #eee;
+		}
+
+		.container {
+			margin-top: 30px;
+		}
+
+		.message {
+			margin-top: 20px;
+			padding: 0 15px 0 15px;
+			border-radius: 5px;
+			border: 1px solid #eee;
+		}
+
+		details {
+			margin: 16px 0 16px 0;
+		}
+
+		summary {
+			font-weight: bold;
+		}
+
+		.issues-list {
+			margin-left: 0;
+			padding-left: 0;
+			list-style: none;
+		}
+
+		.issue {
+			border-radius: 5px;
+			padding: 10px;
+			border: 1px solid #eee;
+			background-color: white;
+		}
+
+		pre {
+			margin: 0;
+		}
+
+		.error {
+			background-color: #fdd;
+			border-color: #ff9696;
+		}
+		.warning {
+			background-color: #ffd;
+			border-color: #e7c12b;
+		}
+		.notice {
+			background-color: #eef4ff;
+			border-color: #b6d0ff;
+		}
+
+	</style>
+
+</head>
+<body>
+
+	<div class="page">
+
+		<h1>Accessibility Report for "{{{name}}}"</h1>
+		<p><b>Run on:</b> {{{pageUrl}}}</p>
+		<p><b>Generated at:</b> {{date}}</p>
+		<p><b>Page screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
+
+		<nav class="counts">
+			<a href="#error" class="count error">{{errorCount}} total errors</a>
+			<a href="#warning" class="count warning">{{warningCount}} total warnings</a>
+			<a href="#notice" class="count notice">{{noticeCount}} total notices</a>
+		</nav>
+
+		{{#issueData}}
+		<div id="{{type}}" class="container">
+			<h2>{{typeLabel}}, {{typeCount}} rule(s)</h2>
+			{{#messages}}
+			<div class="message {{type}}">
+				<h3>{{message}}</h3>
+				<p><b>Rule:</b> {{runner}}, {{code}}</p>
+				{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
+				<hr>
+				<details>
+					<summary>
+						{{issueCount}} instance(s):
+					</summary>
+					<ul class="issues-list">
+						{{#issues}}
+						<li class="issue">
+							<pre>{{selector}}</pre>
+							<hr>
+							<pre>{{context}}</pre>
+						</li>
+						{{/issues}}
+					</ul>
+				</details>
+			</div>
+			{{/messages}}
+		</div>
+		{{/issueData}}
+
+	</div>
+
+</body>
+</html>

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -44,22 +44,7 @@
 			margin: 0 auto;
 			padding: 25px;
 		}
-
-		.counts {
-			font-size: 20px;
-		}
-
-		.count {
-			display: inline-block;
-			padding: 10px;
-			border-radius: 5px;
-			border: 3px solid black;
-		}
-
-		.container {
-			margin-top: 30px;
-		}
-
+		
 		.message {
 			margin-top: 20px;
 			padding: 8px 16px;
@@ -68,7 +53,9 @@
 		}
 
 		details {
-			margin: 8px 0;
+			padding: 8px 0;
+			clear: both;
+			border-top: 1px solid black;
 		}
 
 		summary {
@@ -91,61 +78,61 @@
 		.issue {
 			border-radius: 5px;
 			padding: 10px;
-			border: 3px solid black;
-			background-color: white;
+			background-color: #eee;
 			flex-grow: 1;
 		}
 
-		.diff {
-			font-size: 30px;
-		}
-
 		.error {
-			background-color: #fdd;
-			border-color: #ff9696;
+			border-color: #ff4a4a;
 		}
 
 		.warning {
-			background-color: #ffd;
 			border-color: #e7c12b;
 		}
 
 		.notice {
-			background-color: #eef4ff;
-			border-color: #b6d0ff;
+			border-color: #6a9fff;
 		}
 
-		.removed {
-			background-color: #D9F6D5;
-			border-color: #B9EFB0;
+		.rule {
+			float: left;
+			margin-right: 8px;
 		}
 
-		.added {
-			background-color: #FBECEE;
-			border-color: #F7CFD3;
-		}
-
-		[role="tab"],
-		[role="tab"]:focus,
-		[role="tab"]:hover {
+		.tab,
+		.tab:focus,
+		.tab:hover {
 			display: inline-block;
 			padding: 16px;
 			border: 3px solid gray;
     	border-radius: 5px 5px 0 0;
-			font-size: 16px;
+			font-size: 20px;
 			font-weight: bold;
 			cursor: pointer;
     	background-color: white;
 		}
 
-		[role="tab"][aria-selected="true"] {
+		.tab[aria-selected="true"] {
 		  border-top-width: 6px;
 		  border-top-color: rgb(36 116 214);
 			border-bottom-color: white;
 		}
 
-		[role="tabpanel"] {
-			padding: 8px 16px;
+		.tab.nochange {
+			border-radius: 5px;
+		}
+
+		.tab.removed {
+			background-color: #D9F6D5;
+		}
+
+		.tab.added {
+			background-color: #FBECEE;
+		}
+
+		.tabpanel {
+			padding: 16px;
+			padding-top: 0;
 			margin-top: -3px;
 		  border: 3px solid gray;
 		  border-radius: 0 5px 5px;
@@ -153,14 +140,13 @@
 			box-sizing: border-box;
 		}
 
-		[role="tabpanel"].is-hidden {
+		.tabpanel.is-hidden {
 		  display: none;
 		}
 	</style>
 	<script>
-		function setSelectedTab( currentTab ) {
-		  var tabs = document.querySelectorAll('[role=tab]');
-		  var tabpanels = document.querySelectorAll('[role=tabpanel]');
+		function setSelectedTab( currentTab, tabs, tabGroup ) {
+		  var tabpanels = tabGroup.querySelectorAll('[role=tabpanel]');
 			tabs.forEach( ( tab, i ) => {
 				if (currentTab === tab) {
   	      tab.setAttribute('aria-selected', 'true');
@@ -173,11 +159,14 @@
   	}
 
 		window.addEventListener('load', function () {
-		  var tabs = document.querySelectorAll('[role=tab]');
-			tabs.forEach( ( tab ) => {
-				tab.addEventListener( 'click', ( e ) => {
-					setSelectedTab( e.currentTarget );
-				} );
+		  var tabGroups = document.querySelectorAll('.tabs');
+			tabGroups.forEach( ( tabGroup ) => {
+		  	var tabs = tabGroup.querySelectorAll('[role=tab]');
+				tabs.forEach( ( tab ) => {
+					tab.addEventListener( 'click', ( e ) => {
+						setSelectedTab( e.currentTarget, tabs, tabGroup );
+					} );
+				} )
 			} )
 		});
 	</script>
@@ -190,65 +179,66 @@
 		<h1>Accessibility Report for "{{{name}}}"</h1>
 		<p><b>Run on:</b> {{{pageUrl}}}</p>
 		<p><b>Generated at:</b> {{date}}</p>
-		<p><b>Page screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
+		<p><b>Test patch screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
 
+		<h2 id="tablist-label">Overview of changes</h2>
+		{{^diffData}}
+		<div class="tab nochange">
+			✅ No change
+    </div>
+		{{/diffData}}
 		{{#diffData}}
-		<h2>Diff</h2>
-
-		<h3>Overview</h3>
-
-		<nav class="counts" aria-label="Issue diff counts">
-			{{#totalRemovedCount}}<span class="count removed">🎉 {{.}} removed</span>{{/totalRemovedCount}}
-			{{#totalAddedCount}}<span class="count added">⚠️ {{.}} added</span>{{/totalAddedCount}}
-			{{^diffData}}<span class="count">✅ No change in reported issues</span>{{/diffData}}	
-		</nav>
-
-		{{#data}}
-		<div id="{{type}}-diff" class="container">
-			<h3>{{typeLabel}}: -{{removedCount}}, +{{addedCount}} rule(s)</h3>
-			{{#codes}}
-			<div class="message">
-				<h4>{{message}}</h4>
-				<p><b>Rule:</b> {{runner}}, {{code}}</p>
-				{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
-				<hr>
-				<details>
-					<summary>
-						{{issueCount}} issue(s):
-					</summary>
-					<ul class="issues-list">
-						{{#issues}}
-						<li>
-							<div class="diff">{{#isDeletion}}-{{/isDeletion}}{{^isDeletion}}+{{/isDeletion}}</div>
-							<div class="issue {{#isDeletion}}removed{{/isDeletion}}{{^isDeletion}}added{{/isDeletion}}">
-								<pre>{{selector}}<hr>{{context}}</pre>
-							</div>
-						</li>
-						{{/issues}}
-					</ul>
-				</details>
+		<div class="tabs">
+			<div role="tablist" aria-labelledby="tablist-label">
+				{{#removedData}}
+				<button id="tab-{{name}}" type="button" class="tab removed" role="tab" aria-selected="false" aria-controls="tabpanel-{{name}}">
+					🎉 Solved issues ({{totalCount}})
+    		</button>
+				{{/removedData}}
+				{{#addedData}}
+				<button id="tab-{{name}}" type="button" class="tab added" role="tab" aria-selected="true" aria-controls="tabpanel-{{name}}">
+					⚠️ New issues ({{totalCount}})
+    		</button>
+				{{/addedData}}
 			</div>
-			{{/codes}}
+			{{#removedData}}
+			<div id="tabpanel-{{name}}" class="tabpanel" role="tabpanel" aria-labelledby="tab-{{name}}">
+				{{#resultsData}}{{>Results}}{{/resultsData}}
+			</div>
+			{{/removedData}}
+	 		{{#addedData}}
+			<div id="tabpanel-{{name}}" class="tabpanel" role="tabpanel" aria-labelledby="tab-{{name}}" class="is-hidden">
+				{{#resultsData}}{{>Results}}{{/resultsData}}
+			</div>
+			{{/addedData}}
 		</div>
-		{{/data}}
 		{{/diffData}}
 
+		<h2 id="tablist-label">All issues found</h2>
 		<div class="tabs">
-			<h2 id="tablist-label">Individual patches</h3>
 			<div role="tablist" aria-labelledby="tablist-label">
-				<button id="tab-reference" type="button" role="tab" aria-selected="false" aria-controls="tabpanel-reference">
-					Reference
+				{{#referenceData}}
+				<button id="tab-reference" type="button" class="tab" role="tab" aria-selected="false" aria-controls="tabpanel-reference">
+					Reference ({{totalCount}})
     		</button>
-    		<button id="tab-test" type="button" role="tab" aria-selected="true" aria-controls="tabpanel-test">
-     			Test
+				{{/referenceData}}
+				{{#testData}}
+    		<button id="tab-test" type="button" class="tab" role="tab" aria-selected="true" aria-controls="tabpanel-test">
+     			Test ({{totalCount}})
     		</button>
+				{{/testData}}
 			</div>
-			<div id="tabpanel-reference" role="tabpanel" aria-labelledby="tab-reference" class="is-hidden">
-				{{#referenceData}}{{>Results}}{{/referenceData}}
+			{{#referenceData}}
+			<div id="tabpanel-{{name}}" class="tabpanel" role="tabpanel" aria-labelledby="tab-{{name}}">
+				{{#resultsData}}{{>Results}}{{/resultsData}}
 			</div>
-	 		<div id="tabpanel-test" role="tabpanel" aria-labelledby="tab-test">
-				{{#testData}}{{>Results}}{{/testData}}
+			{{/referenceData}}
+			{{#testData}}
+			<div id="tabpanel-{{name}}" class="tabpanel" role="tabpanel" aria-labelledby="tab-{{name}}" class="is-hidden">
+				{{#resultsData}}{{>Results}}{{/resultsData}}
 			</div>
+			{{/testData}}
+		</div>
 	</div>
 
 </body>

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -6,7 +6,6 @@
 	<title>Accessibility Report For "{{pageUrl}}" ({{date}})</title>
 
 	<style>
-
 		html, body {
 			margin: 0;
 			padding: 0;
@@ -16,12 +15,28 @@
 			line-height: 22px;
 			color: #333;
 		}
+
 		li {
 			margin-bottom: 15px;
 		}
+
 		pre {
 			white-space: pre-wrap;
 			overflow: auto;
+			margin: 0;
+			width: 100%;
+		}
+
+		h2 {
+			margin-top: 32px
+		}
+
+		h4 {
+			margin: 8px 0;
+		}
+
+		p {
+			margin: 0 0 8px 0;
 		}
 
 		.page {
@@ -34,11 +49,12 @@
 			margin-top: 30px;
 			font-size: 20px;
 		}
+
 		.count {
 			display: inline-block;
-			padding: 5px;
+			padding: 10px;
 			border-radius: 5px;
-			border: 1px solid #eee;
+			border: 3px solid black;
 		}
 
 		.container {
@@ -47,13 +63,13 @@
 
 		.message {
 			margin-top: 20px;
-			padding: 0 15px 0 15px;
+			padding: 8px 15px;
 			border-radius: 5px;
-			border: 1px solid #eee;
+			border: 3px solid black;
 		}
 
 		details {
-			margin: 16px 0 16px 0;
+			margin: 8px 0;
 		}
 
 		summary {
@@ -66,28 +82,48 @@
 			list-style: none;
 		}
 
+		li {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			column-gap: 8px;
+		}
+
 		.issue {
 			border-radius: 5px;
 			padding: 10px;
-			border: 1px solid #eee;
+			border: 3px solid black;
 			background-color: white;
+			flex-grow: 1;
 		}
 
-		pre {
-			margin: 0;
+		.diff {
+			font-size: 30px;
 		}
 
 		.error {
 			background-color: #fdd;
 			border-color: #ff9696;
 		}
+
 		.warning {
 			background-color: #ffd;
 			border-color: #e7c12b;
 		}
+
 		.notice {
 			background-color: #eef4ff;
 			border-color: #b6d0ff;
+		}
+
+		.removed {
+			background-color: #D9F6D5;
+			border-color: #B9EFB0;
+		}
+
+		.added {
+			background-color: #FBECEE;
+			border-color: #F7CFD3;
 		}
 
 	</style>
@@ -102,31 +138,35 @@
 		<p><b>Generated at:</b> {{date}}</p>
 		<p><b>Page screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
 
-		<nav class="counts">
-			<a href="#error" class="count error">{{errorCount}} total errors</a>
-			<a href="#warning" class="count warning">{{warningCount}} total warnings</a>
-			<a href="#notice" class="count notice">{{noticeCount}} total notices</a>
+		<h2>Diff results</h2>
+		
+		<nav class="counts" aria-label="Issue diff counts">
+			{{#removedCount}}<span class="count removed">🎉 {{.}} removed</span>{{/removedCount}}
+			{{#addedCount}}<span class="count added">⚠️ {{.}} added</span>{{/addedCount}}
+			{{^diffData}}<span class="count">✅ No change in reported issues</span>{{/diffData}}	
 		</nav>
 
-		{{#issueData}}
-		<div id="{{type}}" class="container">
-			<h2>{{typeLabel}}, {{typeCount}} rule(s)</h2>
+
+		{{#diffData}}
+		<div id="{{type}}-diff" class="container">
+			<h3>{{typeLabel}}: -{{removedCount}}, +{{addedCount}} rule(s)</h3>
 			{{#messages}}
-			<div class="message {{type}}">
-				<h3>{{message}}</h3>
+			<div class="message">
+				<h4>{{message}}</h4>
 				<p><b>Rule:</b> {{runner}}, {{code}}</p>
 				{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
 				<hr>
 				<details>
 					<summary>
-						{{issueCount}} instance(s):
+						{{issueCount}} issue(s):
 					</summary>
 					<ul class="issues-list">
 						{{#issues}}
-						<li class="issue">
-							<pre>{{selector}}</pre>
-							<hr>
-							<pre>{{context}}</pre>
+						<li>
+							<div class="diff">{{#isDeletion}}-{{/isDeletion}}{{^isDeletion}}+{{/isDeletion}}</div>
+							<div class="issue {{#isDeletion}}removed{{/isDeletion}}{{^isDeletion}}added{{/isDeletion}}">
+								<pre>{{selector}}<hr>{{context}}</pre>
+							</div>
 						</li>
 						{{/issues}}
 					</ul>
@@ -134,8 +174,41 @@
 			</div>
 			{{/messages}}
 		</div>
-		{{/issueData}}
+		{{/diffData}}
 
+		<h2>All results</h2>
+
+		<nav class="counts" aria-label="Issue counts">
+			{{#errorCount}}<a href="#error" class="count error">{{.}} error(s)</a>{{/errorCount}}
+			{{#warningCount}}<a href="#warning" class="count warning">{{.}} warning(s)</a>{{/warningCount}}
+			{{#noticeCount}}<a href="#notice" class="count notice">{{.}} notice(s)</a>{{/noticeCount}}
+		</nav>
+
+		{{#totalData}}
+		<div id="{{type}}" class="container">
+			<h3>{{typeLabel}}: {{typeCount}} rule(s)</h3>
+			{{#messages}}
+			<div class="message {{type}}">
+				<h4>{{message}}</h4>
+				<p><b>Rule:</b> {{runner}}, {{code}}</p>
+				{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
+				<hr>
+				<details>
+					<summary>
+						{{issueCount}} issue(s):
+					</summary>
+					<ul class="issues-list">
+						{{#issues}}
+						<li class="issue">
+							<pre>{{selector}}<hr>{{context}}</pre>
+						</li>
+						{{/issues}}
+					</ul>
+				</details>
+			</div>
+			{{/messages}}
+		</div>
+		{{/totalData}}
 	</div>
 
 </body>

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -17,7 +17,7 @@
 		}
 
 		li {
-			margin-bottom: 15px;
+			margin-bottom: 16px;
 		}
 
 		pre {
@@ -46,7 +46,6 @@
 		}
 
 		.counts {
-			margin-top: 30px;
 			font-size: 20px;
 		}
 
@@ -63,7 +62,7 @@
 
 		.message {
 			margin-top: 20px;
-			padding: 8px 15px;
+			padding: 8px 16px;
 			border-radius: 5px;
 			border: 3px solid black;
 		}
@@ -126,7 +125,62 @@
 			border-color: #F7CFD3;
 		}
 
+		[role="tab"],
+		[role="tab"]:focus,
+		[role="tab"]:hover {
+			display: inline-block;
+			padding: 16px;
+			border: 3px solid gray;
+    	border-radius: 5px 5px 0 0;
+			font-size: 16px;
+			font-weight: bold;
+			cursor: pointer;
+    	background-color: white;
+		}
+
+		[role="tab"][aria-selected="true"] {
+		  border-top-width: 6px;
+		  border-top-color: rgb(36 116 214);
+			border-bottom-color: white;
+		}
+
+		[role="tabpanel"] {
+			padding: 8px 16px;
+			margin-top: -3px;
+		  border: 3px solid gray;
+		  border-radius: 0 5px 5px;
+		  width: 100%;
+			box-sizing: border-box;
+		}
+
+		[role="tabpanel"].is-hidden {
+		  display: none;
+		}
 	</style>
+	<script>
+		function setSelectedTab( currentTab ) {
+		  var tabs = document.querySelectorAll('[role=tab]');
+		  var tabpanels = document.querySelectorAll('[role=tabpanel]');
+			tabs.forEach( ( tab, i ) => {
+				if (currentTab === tab) {
+  	      tab.setAttribute('aria-selected', 'true');
+  	      tabpanels[i].classList.remove('is-hidden');
+  	    } else {
+  	      tab.setAttribute('aria-selected', 'false');
+  	      tabpanels[i].classList.add('is-hidden');
+  	    }
+			} );
+  	}
+
+		window.addEventListener('load', function () {
+		  var tabs = document.querySelectorAll('[role=tab]');
+			tabs.forEach( ( tab ) => {
+				tab.addEventListener( 'click', ( e ) => {
+					setSelectedTab( e.currentTarget );
+				} );
+			} )
+		});
+	</script>
 
 </head>
 <body>
@@ -138,16 +192,18 @@
 		<p><b>Generated at:</b> {{date}}</p>
 		<p><b>Page screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
 
-		<h2>Diff results</h2>
-		
+		{{#diffData}}
+		<h2>Diff</h2>
+
+		<h3>Overview</h3>
+
 		<nav class="counts" aria-label="Issue diff counts">
-			{{#removedCount}}<span class="count removed">🎉 {{.}} removed</span>{{/removedCount}}
-			{{#addedCount}}<span class="count added">⚠️ {{.}} added</span>{{/addedCount}}
+			{{#totalRemovedCount}}<span class="count removed">🎉 {{.}} removed</span>{{/totalRemovedCount}}
+			{{#totalAddedCount}}<span class="count added">⚠️ {{.}} added</span>{{/totalAddedCount}}
 			{{^diffData}}<span class="count">✅ No change in reported issues</span>{{/diffData}}	
 		</nav>
 
-
-		{{#diffData}}
+		{{#data}}
 		<div id="{{type}}-diff" class="container">
 			<h3>{{typeLabel}}: -{{removedCount}}, +{{addedCount}} rule(s)</h3>
 			{{#codes}}
@@ -174,41 +230,25 @@
 			</div>
 			{{/codes}}
 		</div>
+		{{/data}}
 		{{/diffData}}
 
-		<h2>All results</h2>
-
-		<nav class="counts" aria-label="Issue counts">
-			{{#errorCount}}<a href="#error" class="count error">{{.}} error(s)</a>{{/errorCount}}
-			{{#warningCount}}<a href="#warning" class="count warning">{{.}} warning(s)</a>{{/warningCount}}
-			{{#noticeCount}}<a href="#notice" class="count notice">{{.}} notice(s)</a>{{/noticeCount}}
-		</nav>
-
-		{{#totalData}}
-		<div id="{{type}}" class="container">
-			<h3>{{typeLabel}}: {{typeCount}} rule(s)</h3>
-			{{#codes}}
-			<div class="message {{type}}">
-				<h4>{{message}}</h4>
-				<p><b>Rule:</b> {{runner}}, {{code}}</p>
-				{{#runnerExtras}}<p><b>Impact:</b> {{impact}}</p>{{/runnerExtras}}
-				<hr>
-				<details>
-					<summary>
-						{{issueCount}} issue(s):
-					</summary>
-					<ul class="issues-list">
-						{{#issues}}
-						<li class="issue">
-							<pre>{{selector}}<hr>{{context}}</pre>
-						</li>
-						{{/issues}}
-					</ul>
-				</details>
+		<div class="tabs">
+			<h2 id="tablist-label">Individual patches</h3>
+			<div role="tablist" aria-labelledby="tablist-label">
+				<button id="tab-reference" type="button" role="tab" aria-selected="false" aria-controls="tabpanel-reference">
+					Reference
+    		</button>
+    		<button id="tab-test" type="button" role="tab" aria-selected="true" aria-controls="tabpanel-test">
+     			Test
+    		</button>
 			</div>
-			{{/codes}}
-		</div>
-		{{/totalData}}
+			<div id="tabpanel-reference" role="tabpanel" aria-labelledby="tab-reference" class="is-hidden">
+				{{#referenceData}}{{>Results}}{{/referenceData}}
+			</div>
+	 		<div id="tabpanel-test" role="tabpanel" aria-labelledby="tab-test">
+				{{#testData}}{{>Results}}{{/testData}}
+			</div>
 	</div>
 
 </body>

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -179,7 +179,6 @@
 		<h1>Accessibility Report for "{{{name}}}"</h1>
 		<p><b>Run on:</b> {{{pageUrl}}}</p>
 		<p><b>Generated at:</b> {{date}}</p>
-		<p><b>Test patch screenshot:</b> <a href="./{{{name}}}.png">{{{name}}}.png</a></p>
 
 		<h2 id="tablist-label">Overview of changes</h2>
 		{{^diffData}}

--- a/src/a11y/reporter/report.mustache
+++ b/src/a11y/reporter/report.mustache
@@ -150,7 +150,7 @@
 		{{#diffData}}
 		<div id="{{type}}-diff" class="container">
 			<h3>{{typeLabel}}: -{{removedCount}}, +{{addedCount}} rule(s)</h3>
-			{{#messages}}
+			{{#codes}}
 			<div class="message">
 				<h4>{{message}}</h4>
 				<p><b>Rule:</b> {{runner}}, {{code}}</p>
@@ -172,7 +172,7 @@
 					</ul>
 				</details>
 			</div>
-			{{/messages}}
+			{{/codes}}
 		</div>
 		{{/diffData}}
 
@@ -187,7 +187,7 @@
 		{{#totalData}}
 		<div id="{{type}}" class="container">
 			<h3>{{typeLabel}}: {{typeCount}} rule(s)</h3>
-			{{#messages}}
+			{{#codes}}
 			<div class="message {{type}}">
 				<h4>{{message}}</h4>
 				<p><b>Rule:</b> {{runner}}, {{code}}</p>
@@ -206,7 +206,7 @@
 					</ul>
 				</details>
 			</div>
-			{{/messages}}
+			{{/codes}}
 		</div>
 		{{/totalData}}
 	</div>

--- a/src/a11y/reporter/reporter.js
+++ b/src/a11y/reporter/reporter.js
@@ -1,74 +1,160 @@
 // @ts-nocheck
 'use strict';
 
-const mustache = require( 'mustache' );// eslint-disable-line
+const mustache = require( 'mustache' );  // eslint-disable-line
 
 const report = module.exports = {};
+
+// Pa11y version support
+report.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta';
 
 // Utility function to uppercase the first character of a string
 function upperCaseFirst( string ) {
 	return string.charAt( 0 ).toUpperCase() + string.slice( 1 );
 }
 
-// Pa11y version support
-report.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta';
+// Constructs unique key for issue
+function getIssueKey( issue ) {
+	return `${issue.code}${issue.selector}`;
+}
 
-// Compile template and output formatted results
-report.results = async ( referenceResults, testResults, reportTemplate ) => {
-	// FIXME: Update reporter to show difference in results
-	const results = testResults;
+// Converts array of issues into a map
+function getIssuesMap( issues ) {
+	return issues.reduce( ( result, issue ) => {
+		result[ getIssueKey( issue ) ] = issue;
+		return result;
+	}, {} );
+}
 
-	const messagesByType = results.issues.reduce( ( result, issue ) => {
-		// eslint-disable-next-line
-		if ( result[ issue.type ].indexOf( issue.message ) === -1 ) {
+// Converts array of issues into a map
+// where the key is the type, and the value is an array of messages
+function getMessagesByType( issues ) {
+	return issues.reduce( ( result, issue ) => {
+		if ( !result[ issue.type ] ) {
+			result[ issue.type ] = [ issue.message ];
+		} else if ( !result[ issue.type ].includes( issue.message ) ) {
 			result[ issue.type ].push( issue.message );
 		}
 		return result;
-	}, { error: [], warning: [], notice: [] } );
-	const issuesByMessage = results.issues.reduce( ( result, issue ) => {
-		if ( result[ issue.message ] ) {
-			result[ issue.message ].push( issue );
-		} else {
+	}, {} );
+}
+
+// Converts array of issues into a map
+// where the key is the message, and the value is an array of issues
+function getIssuesByMessage( issues ) {
+	return issues.reduce( ( result, issue ) => {
+		if ( !result[ issue.message ] ) {
 			result[ issue.message ] = [ issue ];
+		} else {
+			result[ issue.message ].push( issue );
 		}
 		return result;
 	}, {} );
-	const issueData = [ 'error', 'warning', 'notice' ].map( ( type ) => ( {
+}
+
+function getTypes( messagesByType ) {
+	const values = {
+		error: -1,
+		warning: 0,
+		notice: 1
+	};
+	return Object.keys( messagesByType ).sort( ( a, b ) => {
+		return values[ a ] - values[ b ];
+	} );
+}
+
+function getMessageTemplateData( type, messagesByType, issuesByMessage ) {
+	return messagesByType[ type ].map( ( message ) => {
+		const firstIssue = issuesByMessage[ message ][ 0 ];
+		const hasRunnerExtras = Object.keys( firstIssue.runnerExtras ).length > 0;
+		return {
+			message,
+			issueCount: issuesByMessage[ message ].length,
+			runner: firstIssue.runner,
+			runnerExtras: hasRunnerExtras ? firstIssue.runnerExtras : false,
+			code: firstIssue.code,
+			issues: issuesByMessage[ message ]
+		};
+	} ).sort( ( a, b ) => {
+		// Sort messages by number of issues
+		return b.issueCount - a.issueCount;
+	} );
+}
+
+function processDiffData( issues, issuesByDiff ) {
+	const messagesByType = getMessagesByType( issues );
+	const issuesByMessage = getIssuesByMessage( issues );
+
+	const types = getTypes( messagesByType );
+	const issueData = types.map( ( type ) => ( {
+		type,
+		typeLabel: upperCaseFirst( type ) + 's',
+		removedCount: issuesByDiff[ '-' ].filter( ( issue ) => issue.type === type ).length,
+		addedCount: issuesByDiff[ '+' ].filter( ( issue ) => issue.type === type ).length,
+		messages: getMessageTemplateData( type, messagesByType, issuesByMessage )
+	} ) );
+	return issueData;
+}
+
+function processTotalData( issues ) {
+	const messagesByType = getMessagesByType( issues );
+	const issuesByMessage = getIssuesByMessage( issues );
+
+	const types = getTypes( messagesByType );
+	const issueData = types.map( ( type ) => ( {
 		type,
 		typeLabel: upperCaseFirst( type ) + 's',
 		typeCount: messagesByType[ type ].length,
-		messages: messagesByType[ type ].map( ( message ) => {
-			const firstIssue = issuesByMessage[ message ][ 0 ];
-			const hasRunnerExtras = Object.keys( firstIssue.runnerExtras ).length > 0;
-			return {
-				message,
-				issueCount: issuesByMessage[ message ].length,
-				runner: firstIssue.runner,
-				runnerExtras: hasRunnerExtras ? firstIssue.runnerExtras : false,
-				code: firstIssue.code,
-				issues: issuesByMessage[ message ]
-			};
-		} ).sort( ( a, b ) => {
-			// Sort messages by number of issues
-			return b.issueCount - a.issueCount;
-		} )
+		messages: getMessageTemplateData( type, messagesByType, issuesByMessage )
 	} ) );
+	return issueData;
+}
+
+// Compile template and output formatted results
+report.results = async ( referenceResults, testResults, reportTemplate ) => {
+	const issuesByDiff = { '-': [], '+': [] };
+	const referenceMap = getIssuesMap( referenceResults.issues );
+	const testMap = getIssuesMap( testResults.issues );
+	const removedIssues = referenceResults.issues
+		.filter( ( issue ) => !testMap[ getIssueKey( issue ) ] )
+		.map( ( issue ) => {
+			issue.isDeletion = true;
+			issuesByDiff[ '-' ].push( issue );
+			return issue;
+		} );
+	const addedIssues = testResults.issues
+		.filter( ( issue ) => !referenceMap[ getIssueKey( issue ) ] )
+		.map( ( issue ) => {
+			issue.isDeletion = false;
+			issuesByDiff[ '+' ].push( issue );
+			return issue;
+		} );
+
+	const diffData = processDiffData( addedIssues.concat( removedIssues ), issuesByDiff );
+	const totalData = processTotalData( testResults.issues );
+
+	const errorCount = testResults.issues.filter( ( issue ) => issue.type === 'error' ).length;
+	const warningCount = testResults.issues.filter( ( issue ) => issue.type === 'warning' ).length;
+	const noticeCount = testResults.issues.filter( ( issue ) => issue.type === 'notice' ).length;
 
 	return mustache.render( reportTemplate, {
 		// The current date
 		date: new Date(),
 
 		// Test information
-		name: results.name,
-		pageUrl: results.pageUrl,
+		name: testResults.name,
+		pageUrl: testResults.pageUrl,
 
 		// Results
-		issueData,
+		diffData,
+		totalData,
 
 		// Issue counts
-		errorCount: results.issues.filter( ( issue ) => issue.type === 'error' ).length,
-		warningCount: results.issues.filter( ( issue ) => issue.type === 'warning' ).length,
-		noticeCount: results.issues.filter( ( issue ) => issue.type === 'notice' ).length
+		errorCount: errorCount > 0 && errorCount,
+		warningCount: warningCount > 0 && warningCount,
+		noticeCount: noticeCount > 0 && noticeCount,
+		removedCount: removedIssues.length > 0 && removedIssues.length,
+		addedCount: addedIssues.length > 0 && addedIssues.length
 	} );
 };
 

--- a/src/a11y/reporter/reporter.js
+++ b/src/a11y/reporter/reporter.js
@@ -27,85 +27,85 @@ function getIssuesMap( issues ) {
 }
 
 // Converts array of issues into a map
-// where the key is the type, and the value is an array of messages
-function getMessagesByType( issues ) {
+// where the key is the type, and the value is an array of codes
+function getCodesByType( issues ) {
 	return issues.reduce( ( result, issue ) => {
 		if ( !result[ issue.type ] ) {
-			result[ issue.type ] = [ issue.message ];
-		} else if ( !result[ issue.type ].includes( issue.message ) ) {
-			result[ issue.type ].push( issue.message );
+			result[ issue.type ] = [ issue.code ];
+		} else if ( !result[ issue.type ].includes( issue.code ) ) {
+			result[ issue.type ].push( issue.code );
 		}
 		return result;
 	}, {} );
 }
 
 // Converts array of issues into a map
-// where the key is the message, and the value is an array of issues
-function getIssuesByMessage( issues ) {
+// where the key is the code, and the value is an array of issues
+function getIssuesByCode( issues ) {
 	return issues.reduce( ( result, issue ) => {
-		if ( !result[ issue.message ] ) {
-			result[ issue.message ] = [ issue ];
+		if ( !result[ issue.code ] ) {
+			result[ issue.code ] = [ issue ];
 		} else {
-			result[ issue.message ].push( issue );
+			result[ issue.code ].push( issue );
 		}
 		return result;
 	}, {} );
 }
 
-function getTypes( messagesByType ) {
+function getTypes( codesByType ) {
 	const values = {
 		error: -1,
 		warning: 0,
 		notice: 1
 	};
-	return Object.keys( messagesByType ).sort( ( a, b ) => {
+	return Object.keys( codesByType ).sort( ( a, b ) => {
 		return values[ a ] - values[ b ];
 	} );
 }
 
-function getMessageTemplateData( type, messagesByType, issuesByMessage ) {
-	return messagesByType[ type ].map( ( message ) => {
-		const firstIssue = issuesByMessage[ message ][ 0 ];
+function getCodeTemplateData( type, codesByType, issuesByCode ) {
+	return codesByType[ type ].map( ( code ) => {
+		const firstIssue = issuesByCode[ code ][ 0 ];
 		const hasRunnerExtras = Object.keys( firstIssue.runnerExtras ).length > 0;
 		return {
-			message,
-			issueCount: issuesByMessage[ message ].length,
+			message: firstIssue.message,
+			issueCount: issuesByCode[ code ].length,
 			runner: firstIssue.runner,
 			runnerExtras: hasRunnerExtras ? firstIssue.runnerExtras : false,
-			code: firstIssue.code,
-			issues: issuesByMessage[ message ]
+			code,
+			issues: issuesByCode[ code ]
 		};
 	} ).sort( ( a, b ) => {
-		// Sort messages by number of issues
+		// Sort codes by number of issues
 		return b.issueCount - a.issueCount;
 	} );
 }
 
 function processDiffData( issues, issuesByDiff ) {
-	const messagesByType = getMessagesByType( issues );
-	const issuesByMessage = getIssuesByMessage( issues );
+	const codesByType = getCodesByType( issues );
+	const issuesByCode = getIssuesByCode( issues );
 
-	const types = getTypes( messagesByType );
+	const types = getTypes( codesByType );
 	const issueData = types.map( ( type ) => ( {
 		type,
 		typeLabel: upperCaseFirst( type ) + 's',
 		removedCount: issuesByDiff[ '-' ].filter( ( issue ) => issue.type === type ).length,
 		addedCount: issuesByDiff[ '+' ].filter( ( issue ) => issue.type === type ).length,
-		messages: getMessageTemplateData( type, messagesByType, issuesByMessage )
+		codes: getCodeTemplateData( type, codesByType, issuesByCode )
 	} ) );
 	return issueData;
 }
 
 function processTotalData( issues ) {
-	const messagesByType = getMessagesByType( issues );
-	const issuesByMessage = getIssuesByMessage( issues );
+	const codesByType = getCodesByType( issues );
+	const issuesByCode = getIssuesByCode( issues );
 
-	const types = getTypes( messagesByType );
+	const types = getTypes( codesByType );
 	const issueData = types.map( ( type ) => ( {
 		type,
 		typeLabel: upperCaseFirst( type ) + 's',
-		typeCount: messagesByType[ type ].length,
-		messages: getMessageTemplateData( type, messagesByType, issuesByMessage )
+		typeCount: codesByType[ type ].length,
+		codes: getCodeTemplateData( type, codesByType, issuesByCode )
 	} ) );
 	return issueData;
 }

--- a/src/a11y/reporter/reporter.js
+++ b/src/a11y/reporter/reporter.js
@@ -1,0 +1,78 @@
+// @ts-nocheck
+'use strict';
+
+const mustache = require( 'mustache' );// eslint-disable-line
+
+const report = module.exports = {};
+
+// Utility function to uppercase the first character of a string
+function upperCaseFirst( string ) {
+	return string.charAt( 0 ).toUpperCase() + string.slice( 1 );
+}
+
+// Pa11y version support
+report.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta';
+
+// Compile template and output formatted results
+report.results = async ( referenceResults, testResults, reportTemplate ) => {
+	// FIXME: Update reporter to show difference in results
+	const results = testResults;
+
+	const messagesByType = results.issues.reduce( ( result, issue ) => {
+		// eslint-disable-next-line
+		if ( result[ issue.type ].indexOf( issue.message ) === -1 ) {
+			result[ issue.type ].push( issue.message );
+		}
+		return result;
+	}, { error: [], warning: [], notice: [] } );
+	const issuesByMessage = results.issues.reduce( ( result, issue ) => {
+		if ( result[ issue.message ] ) {
+			result[ issue.message ].push( issue );
+		} else {
+			result[ issue.message ] = [ issue ];
+		}
+		return result;
+	}, {} );
+	const issueData = [ 'error', 'warning', 'notice' ].map( ( type ) => ( {
+		type,
+		typeLabel: upperCaseFirst( type ) + 's',
+		typeCount: messagesByType[ type ].length,
+		messages: messagesByType[ type ].map( ( message ) => {
+			const firstIssue = issuesByMessage[ message ][ 0 ];
+			const hasRunnerExtras = Object.keys( firstIssue.runnerExtras ).length > 0;
+			return {
+				message,
+				issueCount: issuesByMessage[ message ].length,
+				runner: firstIssue.runner,
+				runnerExtras: hasRunnerExtras ? firstIssue.runnerExtras : false,
+				code: firstIssue.code,
+				issues: issuesByMessage[ message ]
+			};
+		} ).sort( ( a, b ) => {
+			// Sort messages by number of issues
+			return b.issueCount - a.issueCount;
+		} )
+	} ) );
+
+	return mustache.render( reportTemplate, {
+		// The current date
+		date: new Date(),
+
+		// Test information
+		name: results.name,
+		pageUrl: results.pageUrl,
+
+		// Results
+		issueData,
+
+		// Issue counts
+		errorCount: results.issues.filter( ( issue ) => issue.type === 'error' ).length,
+		warningCount: results.issues.filter( ( issue ) => issue.type === 'warning' ).length,
+		noticeCount: results.issues.filter( ( issue ) => issue.type === 'notice' ).length
+	} );
+};
+
+// Output error messages
+report.error = ( message ) => {
+	return message;
+};

--- a/src/a11y/runA11yTests.js
+++ b/src/a11y/runA11yTests.js
@@ -1,0 +1,179 @@
+// @ts-nocheck
+const fs = require( 'fs' );
+const path = require( 'path' );
+const pa11y = require( 'pa11y' ); // eslint-disable-line
+const puppeteer = require( 'pa11y/node_modules/puppeteer' ); // eslint-disable-line
+const loadCookies = require( '../engine-scripts/puppet/loadCookies' );
+
+const htmlReporter = require( path.resolve( __dirname, './reporter/reporter.js' ) );
+const reportTemplate = fs.readFileSync( path.resolve( __dirname, './reporter/report.mustache' ), 'utf8' );
+
+/**
+ *  Delete and recreate the report directory
+ *
+ * @param {string} type
+ * @param {Object} config
+ */
+function resetDirs( type, config ) {
+	// Delete and create json directory
+	const jsonDir = config.paths[ `a11y_${type}` ];
+	fs.rmSync( jsonDir, { recursive: true, force: true } );
+	fs.mkdirSync( jsonDir, { recursive: true } );
+
+	if ( type === 'test' ) {
+		// Delete and create report directory
+		const reportDir = config.paths.a11y_report;
+		fs.rmSync( reportDir, { recursive: true, force: true } );
+		fs.mkdirSync( reportDir, { recursive: true } );
+	}
+}
+
+/**
+ *  Get array of promises that run accessibility tests using pa11y
+ *
+ * @param {string} type
+ * @param {Object} config
+ * @return {Promise<any>[]}
+ */
+function getTestPromises( type, config ) {
+	return config.tests.map( async ( test ) => {
+		const { url, name, ...testOptions } = test;
+		let options = { ...testOptions, ...{
+			// Automatically enable screen capture for every test;
+			screenCapture: `${config.paths.a11y_report}/${name}.png`
+		} };
+
+		// FIXME: update this to not be hardcoded
+		if ( name === 'logged_in' ) {
+			const browser = await puppeteer.launch( { args: [ '--no-sandbox' ] } );
+			const page = await browser.newPage();
+			await loadCookies( page, 'Admin' );
+			options = { ...options, ...{ browser, page } };
+		}
+
+		return pa11y( url, options ).then( ( result ) => {
+			result.name = name;
+			return result;
+		} );
+	} );
+}
+
+/**
+ *  Log test results to Graphite
+ *
+ * @param {string} namespace
+ * @param {string} name
+ * @param {number} count
+ * @return {Promise<any>}
+ */
+function sendMetrics( namespace, name, count ) {
+	const metricPrefix = 'ci_a11y';
+	const url = `${process.env.WMF_JENKINS_BEACON_URL}${metricPrefix}.${namespace}.${name}=${count}c`;
+	return fetch( url );
+}
+
+/**
+ *  Process test results, log the results to console, Graphite and an HTML report.
+ *
+ * @param {Object[]} testResults
+ * @param {string} type
+ * @param {Object} config
+ * @param {Object} opts
+ */
+async function processTestResults( testResults, type, config, opts ) {
+	testResults.issues.forEach( ( issue ) => {
+		// Reassign axe warnings as errors
+		if ( issue.type === 'warning' && issue.runner === 'axe' ) {
+			issue.type = 'error';
+		}
+	} );
+
+	const errorNum = testResults.issues.filter( ( issue ) => issue.type === 'error' ).length;
+	const warningNum = testResults.issues.filter( ( issue ) => issue.type === 'warning' ).length;
+	const noticeNum = testResults.issues.filter( ( issue ) => issue.type === 'notice' ).length;
+	const name = testResults.name;
+
+	// Log results summary to console
+	console.log( `'${name}'- ${errorNum} errors, ${warningNum} warnings, ${noticeNum} notices` );
+
+	// Send data to Graphite
+	// WMF_JENKINS_BEACON_URL is only defined in CI env
+	if ( opts.logResults ) {
+		await sendMetrics( config.namespace, testResults.name, errorNum )
+			.then( ( response ) => {
+				if ( response.ok ) {
+					console.log( `'${name}' results logged successfully` );
+				} else {
+					console.error( `Failed to log '${name}' results` );
+				}
+			} );
+	}
+
+	// Save in json report
+	const jsonDir = config.paths[ `a11y_${type}` ];
+	fs.writeFileSync( `${jsonDir}/${name}.json`, JSON.stringify( testResults, null, ' ' ), 'utf8' );
+
+	// Save in html report
+	if ( type === 'test' ) {
+		const referenceResults = require( path.resolve( `${config.paths.a11y_reference}/${name}.json` ) );
+		if ( referenceResults ) {
+			const html = await htmlReporter.results(
+				referenceResults,
+				testResults,
+				reportTemplate
+			);
+			fs.writeFileSync( `${config.paths.a11y_report}/${name}.html`, html, 'utf8' );
+		}
+	}
+}
+
+/**
+ *  Run pa11y on tests specified by the config.
+ */
+async function main() {
+	const type = process.argv[ 2 ];
+	const configFile = process.argv[ 3 ];
+	const config = require( `${process.cwd()}/${configFile}` );
+	// FIXME: update this to not be hardcoded
+	const opts = {
+		logResults: false
+	};
+
+	if ( !process.env.PIXEL_MW_SERVER ) {
+		throw new Error( 'Missing env variables' );
+	}
+
+	if ( !type || !config ) {
+		throw new Error( 'Missing arguments' );
+	}
+
+	if ( !config.tests || !config.paths.a11y_report ) {
+		throw new Error( 'Missing config variables' );
+	}
+
+	if ( type === 'test' && !fs.existsSync( config.paths.a11y_reference ) ) {
+		throw new Error( 'Run reference before test' );
+	}
+
+	const tests = config.tests;
+	const allValidTests = tests.filter( ( test ) => test.name ).length === tests.length;
+	if ( !allValidTests ) {
+		throw new Error( 'Config missing test name' );
+	}
+
+	const canLogResults = process.env.WMF_JENKINS_BEACON_URL && config.namespace;
+	if ( opts.logResults && !canLogResults ) {
+		throw new Error( 'Unable to log results, missing config or env variables' );
+	}
+
+	resetDirs( type, config );
+	const testPromises = getTestPromises( type, config );
+	const testResults = await Promise.all( testPromises );
+	const resultPromises = testResults.map( async ( result ) => {
+		await processTestResults( result, type, config, opts );
+	} );
+	await Promise.all( resultPromises );
+	process.exit(); // eslint-disable-line
+}
+
+main();

--- a/src/a11y/runA11yTests.js
+++ b/src/a11y/runA11yTests.js
@@ -81,11 +81,12 @@ function sendMetrics( namespace, name, count ) {
  * @param {Object} opts
  */
 async function processTestResults( testResults, type, config, opts ) {
-	testResults.issues.forEach( ( issue ) => {
-		// Reassign axe warnings as errors
-		if ( issue.type === 'warning' && issue.runner === 'axe' ) {
-			issue.type = 'error';
-		}
+	testResults.issues = testResults.issues.filter( ( issue ) => {
+		// Clean up test results
+		// Remove htmlcs notices (there are too manu) and issues missing data about the element
+		const isHtmlcsNotice = issue.type === 'notice' && issue.runner === 'htmlcs';
+		const isMissingContext = !issue.context;
+		return !isHtmlcsNotice && !isMissingContext;
 	} );
 
 	const errorNum = testResults.issues.filter( ( issue ) => issue.type === 'error' ).length;

--- a/src/a11y/runA11yTests.js
+++ b/src/a11y/runA11yTests.js
@@ -6,7 +6,6 @@ const puppeteer = require( 'pa11y/node_modules/puppeteer' ); // eslint-disable-l
 const loadCookies = require( '../engine-scripts/puppet/loadCookies' );
 
 const htmlReporter = require( path.resolve( __dirname, './reporter/reporter.js' ) );
-const reportTemplate = fs.readFileSync( path.resolve( __dirname, './reporter/report.mustache' ), 'utf8' );
 
 /**
  *  Delete and recreate the report directory
@@ -118,11 +117,7 @@ async function processTestResults( testResults, type, config, opts ) {
 	if ( type === 'test' ) {
 		const referenceResults = require( path.resolve( `${config.paths.a11y_reference}/${name}.json` ) );
 		if ( referenceResults ) {
-			const html = await htmlReporter.results(
-				referenceResults,
-				testResults,
-				reportTemplate
-			);
+			const html = await htmlReporter.results( referenceResults, testResults );
 			fs.writeFileSync( `${config.paths.a11y_report}/${name}.html`, html, 'utf8' );
 		}
 	}

--- a/src/engine-scripts/puppet/loadCookies.js
+++ b/src/engine-scripts/puppet/loadCookies.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const allCookies = require( '../cookies.json' );
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -33,6 +33,21 @@ const makePaths = ( path ) => {
 };
 
 /**
+ * @param {string} path
+ * @return {Object}
+ */
+const makeA11yPaths = ( path ) => {
+	return {
+		// eslint-disable-next-line camelcase
+		a11y_reference: `report-a11y/reference-json-${path}`,
+		// eslint-disable-next-line camelcase
+		a11y_test: `report-a11y/test-json-${path}`,
+		// eslint-disable-next-line camelcase
+		a11y_report: `report-a11y/${path}`
+	};
+};
+
+/**
  * @param {Object} scenario
  * @param {string} scenario.url
  * @param {Object} featureFlags
@@ -82,5 +97,6 @@ const makeScenariosForSkins = ( tests, skins ) => {
 module.exports = {
 	makeScenariosForSkins,
 	makePaths,
+	makeA11yPaths,
 	addFeatureFlagQueryStringsToScenario
 };


### PR DESCRIPTION
### Summary
Adds ability to test for a11y errors to pixel.

- Add new `a11y-regression` docker image
- Use the `pa11y` library to run automated a11y tests
- Create a custom a11y error reporter that shows differences between the 'test' and 'reference' patches

### Notes
At some point, it might make sense to factor out the part of pixel that creates docker containers to compare patches. That logic is what's primarily being leveraged for this new feature, and having a generic tool for comparing patches could be useful for other applications as well. 

### How to test
The `-a` or `--a11y` flag is used to run a11y tests instead of visual tests. 

Run the following to see what a a11y regression would look like
```
./pixel.js reference -a && ./pixel.js test -c 954075 -a
```

Run the following to see what a a11y improvement would look like
```
./pixel.js reference -c 954075 -a && ./pixel.js test -a
```

Run the following to see what no change would look like
```
./pixel.js reference -a && ./pixel.js test -a
```