### PR TITLE
WikiLambda fix

### DIFF
--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -20,7 +20,7 @@ COPY repositories.json /repositories.json
 RUN /src/setupRepos.js "$( cat /repositories.json )"
 
 # Needed to install WikiLambda's dependencies
-RUN cp composer.local.json-sample composer.local.json
+COPY composer.local.json composer.local.json
 
 # Now we can copy the entire src directory since setupRepos.js has executed.
 COPY src /src

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -161,8 +161,9 @@ wfLoadExtension( 'UniversalLanguageSelector' );
 wfLoadExtension( 'VisualEditor' );
 wfLoadExtension( 'GrowthExperiments' );
 wfLoadExtension( 'VueTest' );
-// https://phabricator.wikimedia.org/T343056
-//wfLoadExtension( 'WikiLambda' );
+if ( getenv('ENABLE_WIKILAMBDA') == 'true' ) {
+	wfLoadExtension( 'WikiLambda' );
+}
 wfLoadExtension( 'WikimediaMessages' );
 
 // Make extended cookies (e.g. when logging in with "Keep me logged in" option)

--- a/composer.local.json
+++ b/composer.local.json
@@ -1,9 +1,9 @@
 {
-  "extra": {
-    "merge-plugin": {
-      "include": [
-        "extensions/WikiLambda/composer.json"
-      ]
-    }
-  }
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/WikiLambda/composer.json"
+			]
+		}
+	}
 }

--- a/composer.local.json
+++ b/composer.local.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "merge-plugin": {
+      "include": [
+        "extensions/WikiLambda/composer.json"
+      ]
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - XDEBUG_CONFIG=
       - XDEBUG_ENABLE=false
       - XHPROF_ENABLE=false
+      - ENABLE_WIKILAMBDA=${ENABLE_WIKILAMBDA}
     volumes:
       - mwcode:/var/www/html/w
       - ./LocalSettings.php:/var/www/html/w/LocalSettings.php

--- a/pixel.js
+++ b/pixel.js
@@ -303,8 +303,8 @@ async function processCommand( type, opts, runSilently = false ) {
 	}
 }
 
-function setEnvironmentFlagIfGroup(envVarName, soughtGroup, group) {
-	process.env[envVarName] = group === soughtGroup ? 'true' : 'false';
+function setEnvironmentFlagIfGroup( envVarName, soughtGroup, group ) {
+	process.env[ envVarName ] = group === soughtGroup ? 'true' : 'false';
 }
 
 function setupCli() {
@@ -350,7 +350,7 @@ function setupCli() {
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
-			setEnvironmentFlagIfGroup('ENABLE_WIKILAMBDA', 'wikilambda', opts.group);
+			setEnvironmentFlagIfGroup( 'ENABLE_WIKILAMBDA', 'wikilambda', opts.group );
 			processCommand( 'reference', opts );
 		} );
 
@@ -362,7 +362,7 @@ function setupCli() {
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
-			setEnvironmentFlagIfGroup('ENABLE_WIKILAMBDA', 'wikilambda', opts.group);
+			setEnvironmentFlagIfGroup( 'ENABLE_WIKILAMBDA', 'wikilambda', opts.group );
 			processCommand( 'test', opts );
 		} );
 

--- a/pixel.js
+++ b/pixel.js
@@ -303,6 +303,10 @@ async function processCommand( type, opts, runSilently = false ) {
 	}
 }
 
+function setEnvironmentFlagIfGroup(envVarName, soughtGroup, group) {
+	process.env[envVarName] = group === soughtGroup ? 'true' : 'false';
+}
+
 function setupCli() {
 	const { program } = require( 'commander' );
 	const branchOpt = /** @type {const} */ ( [
@@ -346,6 +350,7 @@ function setupCli() {
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
+			setEnvironmentFlagIfGroup('ENABLE_WIKILAMBDA', 'wikilambda', opts.group);
 			processCommand( 'reference', opts );
 		} );
 
@@ -357,6 +362,7 @@ function setupCli() {
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
+			setEnvironmentFlagIfGroup('ENABLE_WIKILAMBDA', 'wikilambda', opts.group);
 			processCommand( 'test', opts );
 		} );
 


### PR DESCRIPTION
First commit minimizes `composer.local.json` changes from the original WikiLambda PR

Second commit sets an ENV var conditionally so `wfLoadExtension( 'WikiLambda' )` only happens when running either of these:

```
./pixel.js reference --group wikilambda
./pixel.js test --group wikilambda
```