### PR TITLE
Hide pointer overlays via CSS

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -365,6 +365,8 @@ $wgQuickSurveysConfig = [
 $wgHooks['BeforePageDisplay'][] = function ( $out ) {
 	$css = <<<HTML
 <style type="text/css">
+	/* Popup notifications are hidden in visual regression suite as they can appear unpredictably. */
+	.vector-popup-notification { display: none !important; }
 </style>
 HTML;
 	$out->addHTML( $css );

--- a/src/engine-scripts/puppet/fastForwardAnimations.js
+++ b/src/engine-scripts/puppet/fastForwardAnimations.js
@@ -26,15 +26,6 @@ async function fastForwardAnimations( page ) {
 			}
 		} );
 
-		// Hide all popup notifications
-		const popupNotifications = document.querySelectorAll( '.vector-popup-notification' );
-		if ( popupNotifications && popupNotifications.length > 0 ) {
-			popupNotifications.forEach( ( popupNotification ) => {
-				popupNotification.style = '';
-				popupNotification.classList.add( 'oo-ui-element-hidden' );
-			} );
-		}
-
 		// Wait until the next frame before resolving.
 		return new Promise( ( resolve ) => {
 			requestAnimationFrame( () => {


### PR DESCRIPTION
This seems like a more reliable alternative to JavaScript. Pointer overlays can be shown after ajax queries/setTimeout so we can't be confident they are all in the page within this code.
