### PR TITLE
Update desktop dev to be client preferences menu

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -380,15 +380,5 @@ $wgVectorLanguageAlertInSidebar = [
 	"logged_out" => true
 ];
 
-$wgVectorPageTools = [
-	'logged_in' => true,
-	'logged_out' => true
-];
-
 $wgMFAmcOutreachMinEditCount = 0;
 $wgMFAmcOutreach = true;
-$wgVectorZebraDesign = [
-	"logged_in" => true,
-	"logged_out" => true,
-	"beta" => true,
-];

--- a/configDesktopDev.js
+++ b/configDesktopDev.js
@@ -7,7 +7,9 @@ const configDesktop = require( './configDesktop.js' );
 module.exports = Object.assign( {}, configDesktop, {
 	scenarios: configDesktop.scenarios.map(
 		( scenario ) => utils.addFeatureFlagQueryStringsToScenario( scenario, {
-			vectorzebradesign: '1'
+			vectorclientpreferences: '1',
+			vectorcustomfontsize: '1',
+			vectornightmode: '1'
 		} )
 	),
 	paths: utils.makePaths( 'desktop-dev' )

--- a/src/engine-scripts/puppet/limitedWidth.js
+++ b/src/engine-scripts/puppet/limitedWidth.js
@@ -8,6 +8,15 @@ const clickBtn = require( './clickBtn' );
 module.exports = async ( page, hashtags ) => {
 	// limit width by default to ensure consistency between tests
 	// Only disable when hashtag is provided
+	const isClientPrefs = await page.evaluate( () => {
+		return document.documentElement.classList.contains( 'vector-feature-client-preferences-enabled' );
+	} );
+
+	if ( isClientPrefs ) {
+		// FIXME: Handle limited width with client pref menu instead
+		return;
+	}
+
 	const isDisabled = hashtags.includes( '#limited-width-disabled' );
 	const isCurrentlyEnabled = await page.evaluate( () => {
 		return document.documentElement.classList.contains( 'vector-feature-limited-width-clientpref-1' ) ||


### PR DESCRIPTION
Temporarily disabled #limited-width-menu when the client prefs menu is enabled, those settings need new engine scripts in general.