### PR TITLE
Fix a11y groups in runAll command, fix summary page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 report
-report-a11y
 package-lock.json
 coverage
 context.json

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Pixel can also compare accessibility errors between a reference and test patch. 
 ./pixel.js test -c Iff231a976c473217b0fa4da1aa9a8d1c2a1a19f2 --a11y
 ```
 
-The HTML report of the test results can be found at `report-a11y/<name-of-test-group>/<name-of-test>.html`.
+The HTML report of the test results can be found at `report/<name-of-test-group>-a11y/index.html`.
 
 ### Stopping the services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,6 @@ services:
       - ./viewports.js:/pixel/viewports.js
       - ./utils.js:/pixel/utils.js
       - ./configDesktopA11y.js:/pixel/configDesktopA11y.js
-      - ./configDesktopA11y.js:/pixel/configMobileA11y.js
+      - ./configMobileA11y.js:/pixel/configMobileA11y.js
       - ./src:/pixel/src
-      - ./report-a11y:/pixel/report-a11y
+      - ./report:/pixel/report

--- a/pixel.js
+++ b/pixel.js
@@ -497,20 +497,21 @@ function setupCli() {
 			// Update keys in a11y group config to avoid duplicate group names
 			const updatedA11yGroupConfig = {};
 			for ( const key in A11Y_GROUP_CONFIG ) {
-				updatedA11yGroupConfig[ key + 'a11y' ] = A11Y_GROUP_CONFIG[ key ];
+				updatedA11yGroupConfig[ key + '-a11y' ] = A11Y_GROUP_CONFIG[ key ];
 			}
 
 			const groups = { ...GROUP_CONFIG, ...updatedA11yGroupConfig };
-			for ( const [ group, groupDef ] of Object.entries( groups ) ) {
+			for ( const [ groupName, groupDef ] of Object.entries( groups ) ) {
+				const group = groupDef.a11y ? groupName.slice( 0, -5 ) : groupName;
 				const name = groupDef.name || group;
-				html += `<li><a href="${group}/index.html">${name} (${group})</a></li>`;
+				html += `<li><a href="${groupName}/index.html">${name} (${groupName})</a></li>`;
 				const groupPriority = groupDef.priority || 0;
 				if ( groupPriority <= priority ) {
 					console.log( `*************************
 *************************
 *************************
 *************************
-Running regression group "${group}"
+Running regression group "${groupName}"
 *************************
 *************************
 *************************
@@ -537,7 +538,7 @@ Running regression group "${group}"
 					}
 				} else {
 					console.log( `*************************
-Skipping group "${group}" due to priority.
+Skipping group "${groupName}" due to priority.
 *************************` );
 				}
 			}

--- a/report-a11y/.gitignore
+++ b/report-a11y/.gitignore
@@ -1,3 +1,0 @@
-# Ignore everything except this file
-*
-!.gitignore

--- a/src/a11y/reporter/summary.js
+++ b/src/a11y/reporter/summary.js
@@ -1,0 +1,24 @@
+// @ts-nocheck
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const mustache = require( 'mustache' );  // eslint-disable-line
+
+const summaryTemplate = fs.readFileSync( path.resolve( __dirname, './summary.mustache' ), 'utf8' );
+
+async function generateHTML( config ) {
+	const names = config.tests.map( ( test ) => {
+		return test.name;
+	} );
+	return mustache.render( summaryTemplate, {
+		// The current date
+		date: new Date(),
+		group: `${config.namespace}-a11y`,
+		names
+	} );
+}
+
+module.exports = {
+	results: generateHTML
+};

--- a/src/a11y/reporter/summary.mustache
+++ b/src/a11y/reporter/summary.mustache
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+	<meta charset="utf-8"/>
+	<title>Accessibility tests ({{date}})</title>
+
+	<style>
+		html, body {
+			margin: 0;
+			padding: 0;
+			background-color: #fff;
+			font-family: Arial, Helvetica, sans-serif;
+			font-size: 16px;
+			line-height: 22px;
+			color: #333;
+		}
+
+		.page {
+			max-width: 800px;
+			margin: 0 auto;
+			padding: 25px;
+		}
+
+	</style>
+</head>
+<body>
+
+	<div class="page">
+		<h1>Accessibility summary for "{{{group}}}"</h1>
+		<p><b>Generated at:</b> {{date}}</p>
+
+		<ul>
+			{{#names}}
+			<li>
+				<a class="tab" href="./{{.}}.html">
+				{{{.}}}
+   		 	</a>
+			</li>
+			{{/names}}
+		</ul>
+	</div>
+
+</body>
+</html>

--- a/utils.js
+++ b/utils.js
@@ -39,11 +39,11 @@ const makePaths = ( path ) => {
 const makeA11yPaths = ( path ) => {
 	return {
 		// eslint-disable-next-line camelcase
-		a11y_reference: `report-a11y/reference-json-${path}`,
+		a11y_reference: `report/reference-json-${path}-a11y`,
 		// eslint-disable-next-line camelcase
-		a11y_test: `report-a11y/test-json-${path}`,
+		a11y_test: `report/test-json-${path}-a11y`,
 		// eslint-disable-next-line camelcase
-		a11y_report: `report-a11y/${path}`
+		a11y_report: `report/${path}-a11y`
 	};
 };
 


### PR DESCRIPTION
- Refactor how groups works for a11y tests
- Fix the links to accessibility tests in the runAll summary page
- Fix the config for the Minerva a11y tests