### PR TITLE
Run Codex tests against the Codex sandbox instead of Special:VueTest

### DIFF
--- a/configCodex.js
+++ b/configCodex.js
@@ -5,45 +5,141 @@ const {
 	VIEWPORT_DESKTOP
 } = require( './viewports' );
 
-// List of all components currently documented in the VueTest extension's Sandbox page.
-// Dialog is left out because all Dialog demos require interaction to test properly.
-// TODO: Add Link and ProgressBar once their demos are added to the codex-demos package.
+// List of all components on the Codex sandbox
+// TODO ideally we would automate this based on what's actually in the sandbox
 const components = [
-	'button',
-	'button-group',
-	'card',
-	'checkbox',
-	'combobox',
-	'icon',
-	'lookup',
-	'menu',
-	'menu-item',
-	'message',
-	'radio',
-	'search-input',
-	'select',
-	'tabs',
-	'text-input',
-	'thumbnail',
-	'toggle-button',
-	'toggle-button-group',
-	'toggle-switch',
-	'typeahead-search'
+	{
+		label: 'Accordion',
+		sandboxSection: 'accordion'
+	},
+	{
+		label: 'Button',
+		sandboxSection: 'button'
+		// TODO also add a scenario that looks at the full button grid
+		// This will require making the URL (or at least the index.html part of it) customizable
+	},
+	{
+		label: 'Button group',
+		sandboxSection: 'button-group'
+	},
+	{
+		label: 'Card',
+		sandboxSection: 'card'
+	},
+	{
+		label: 'Checkbox',
+		sandboxSection: 'checkbox'
+	},
+	{
+		label: 'Chip input',
+		sandboxSection: 'chip-input'
+	},
+	{
+		label: 'Combobox',
+		sandboxSection: 'combobox'
+	},
+	{
+		label: 'Dialog',
+		sandboxSection: 'dialog'
+		// TODO put clickSelector or something here
+	},
+	{
+		label: 'Field',
+		sandboxSection: 'field'
+	},
+	{
+		label: 'Icon',
+		sandboxSection: 'icon'
+		// TODO also add a scenario that looks at the full icon grid
+	},
+	{
+		label: 'Label',
+		sandboxSection: 'label'
+	},
+	{
+		label: 'Link',
+		sandboxSection: 'link'
+	},
+	{
+		label: 'Lookup',
+		sandboxSection: 'lookup'
+	},
+	{
+		label: 'Menu',
+		sandboxSection: 'menu'
+	},
+	{
+		label: 'Menu item',
+		sandboxSection: 'menu-item'
+	},
+	{
+		label: 'Message',
+		sandboxSection: 'message'
+	},
+	{
+		label: 'Progress bar',
+		sandboxSection: 'progress-bar'
+	},
+	{
+		label: 'Radio',
+		sandboxSection: 'radio'
+	},
+	{
+		label: 'Search input',
+		sandboxSection: 'search-input'
+	},
+	{
+		label: 'Select',
+		sandboxSection: 'select'
+	},
+	{
+		label: 'Tabs',
+		sandboxSection: 'tabs'
+	},
+	{
+		label: 'Text area',
+		sandboxSection: 'text-area'
+	},
+	{
+		label: 'Text input',
+		sandboxSection: 'text-input'
+	},
+	{
+		label: 'Thumbnail',
+		sandboxSection: 'thumbnail'
+	},
+	{
+		label: 'Toggle button group',
+		sandboxSection: 'toggle-button-group'
+	},
+	{
+		label: 'Toggle',
+		sandboxSection: 'toggle'
+	},
+	{
+		label: 'TypeaheadSearch',
+		sandboxSection: 'typeahead-search'
+	}
 ];
 
-const scenarios = utils.makeScenariosForSkins(
-	components.map( ( component ) => {
-		return {
-			label: 'cdx-' + component,
-			path: '/wiki/Special:VueTest/codex',
-			selectors: [ '.cdx-sandbox__content #cdx-' + component ],
-			removeSelectors: [ '.cdx-sandbox__nav', `main > section:not(#cdx-${component}` ],
-			misMatchThreshold: 1
-		};
-	} ),
-	// TODO: add interactive tests for Dialog, clearable Input, and maybe TypeaheadSearch
-	[ 'vector-2022', 'minerva' ]
-);
+const scenarios = components.map( ( componentData ) => {
+	const { sandboxSection, ...otherData } = componentData;
+	/** @type {string[]} */
+	let selectors = [];
+	/** @type {string[]} */
+	let removeSelectors = [];
+	if ( sandboxSection ) {
+		selectors = [ `#cdx-${sandboxSection}` ];
+		removeSelectors = [ `main section:not(#cdx-${sandboxSection})` ];
+	}
+	return {
+		selectors,
+		removeSelectors,
+		...otherData,
+		url: `${process.env.PIXEL_MW_SERVER}/w/codex/packages/codex/dist/sandbox/index.html`,
+		misMatchThreshold: 1
+	};
+} );
 
 module.exports = {
 	id: 'MediaWiki',
@@ -52,8 +148,6 @@ module.exports = {
 		VIEWPORT_TABLET,
 		VIEWPORT_DESKTOP
 	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
 	scenarios,
 	paths: utils.makePaths( 'codex' ),
 	report: [],

--- a/pixel.js
+++ b/pixel.js
@@ -219,8 +219,9 @@ function removeFolder( relativePath ) {
 
 /**
  * @typedef {Object} CommandOptions
- * @property {string} [changeId]
+ * @property {string[]} [changeId]
  * @property {string} [branch]
+ * @property {string[]} [repoBranch]
  * @property {string} group
  */
 
@@ -254,6 +255,9 @@ async function processCommand( type, opts, runSilently = false ) {
 			}
 		} else {
 			active = opts.changeId ? opts.changeId[ 0 ] : opts.branch;
+		}
+		if ( opts.repoBranch && opts.repoBranch.length > 0 ) {
+			active += ` (with custom branches: ${opts.repoBranch.join( ', ' )})`;
 		}
 		if ( !context[ group ] ) {
 			context[ group ] = { description };
@@ -372,6 +376,10 @@ function setupCli() {
 		'-c, --change-id <Change-Id...>',
 		'The Change-Id to use. Use multiple flags to use multiple Change-Ids (e.g. -c <Change-Id> -c <Change-Id>)'
 	] );
+	const repoBranchOpt = /** @type {const} */ ( [
+		'--repo-branch <repo:branch...>',
+		'Override the branch name for a specific repository. Specify the repository name, then a colon, then the branch name, e.g. `mediawiki/skins/Vector:new-vector-features`. Use multiple flags to override branches for multiple repositories.'
+	] );
 	const groupOpt = /** @type {const} */ ( [
 		'-g, --group <(mobile|desktop|echo|campaign-events)>',
 		'The group of tests to run. If omitted the group will be desktop.',
@@ -403,6 +411,7 @@ function setupCli() {
 		.option( ...a11yOpt )
 		.option( ...logResultsOpt )
 		.option( ...changeIdOpt )
+		.option( ...repoBranchOpt )
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
@@ -416,6 +425,7 @@ function setupCli() {
 		.option( ...a11yOpt )
 		.option( ...logResultsOpt )
 		.option( ...changeIdOpt )
+		.option( ...repoBranchOpt )
 		.option( ...groupOpt )
 		.option( ...resetDbOpt )
 		.action( ( opts ) => {
@@ -482,6 +492,7 @@ function setupCli() {
 		.description( 'Runs all the registered tests and generates a report.' )
 		.option( ...branchOpt )
 		.option( ...changeIdOpt )
+		.option( ...repoBranchOpt )
 		.option( ...groupOpt )
 		.option( ...priorityOpt )
 		.option( ...directoryOpt )

--- a/repositories.json
+++ b/repositories.json
@@ -88,5 +88,8 @@
 	},
 	"mediawiki/core": {
 		"path": "."
+	},
+	"design/codex": {
+		"path": "codex"
 	}
 }

--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -126,7 +126,7 @@ class MwCheckout {
 	 * @param {string} repoId
 	 */
 	async #checkoutBranch( path, branch, repoId ) {
-		const { stdout } = await this.#batchSpawn.exec( `git -C "${path}" for-each-ref refs/remotes/origin/ --format='%(refname:short)'` );
+		const { stdout } = await this.#batchSpawn.exec( `git -C "${path}" for-each-ref refs/remotes/origin/ refs/tags/ --format='%(refname:short)'` );
 		const branches = stdout.split( '\n' );
 		// Use the `main` branch instead of `master` if `main` is available and
 		// `master` is unavailable.

--- a/src/MwCheckout.js
+++ b/src/MwCheckout.js
@@ -62,8 +62,9 @@ class MwCheckout {
 	 * `main` are passed, these will be converted to `origin/master` and
 	 * `origin/main`, respectively.
 	 * @param {string[]} changeIds An array of Gerrit Change-Ids
+	 * @param {Object.<string, string>} repoBranches
 	 */
-	async checkout( branch, changeIds ) {
+	async checkout( branch, changeIds, repoBranches = {} ) {
 		if ( branch === 'master' || branch === 'main' ) {
 			branch = `origin/${branch}`;
 		}
@@ -73,8 +74,9 @@ class MwCheckout {
 
 		await Promise.all( Object.keys( this.#repos ).map( async ( repoId ) => {
 			const path = this.#repos[ repoId ].path;
+			const repoBranch = repoBranches[ repoId ] ?? branch;
 			await this.#fetch( path );
-			await this.#checkoutBranch( path, branch, repoId );
+			await this.#checkoutBranch( path, repoBranch, repoId );
 
 			// Apply Gerrit patches, if any.
 			// @ts-ignore

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,13 @@ const BatchSpawn = require( './BatchSpawn' );
 const benchmark = require( './benchmark' );
 const MwCheckout = require( './MwCheckout' );
 
+/** @type {Object.<string, string>} */
+const repoBranches = {};
+for ( const rb of ( opts.repoBranch ?? [] ) ) {
+	const [ repo, branch ] = rb.split( ':' );
+	repoBranches[ repo ] = branch;
+}
+
 /**
  * The number of processing units available.
  *
@@ -21,7 +28,7 @@ async function init() {
 	benchmark( async () => {
 		const batchSpawn = new BatchSpawn( await getProcessingUnitsAvailable() );
 		const mwCheckout = new MwCheckout( repos, batchSpawn );
-		await mwCheckout.checkout( opts.branch, opts.changeId ?? [] );
+		await mwCheckout.checkout( opts.branch, opts.changeId ?? [], repoBranches );
 	} );
 }
 

--- a/utils.js
+++ b/utils.js
@@ -68,6 +68,7 @@ const addFeatureFlagQueryStringsToScenario = ( scenario, featureFlags ) => {
  * @property {string} [hash]
  * @property {Object} [query]
  * @property {string[]} [hashtags]
+ * @property {number} [misMatchThreshold]
  * @property {string} label
  * @property {string[]} selectors
  *


### PR DESCRIPTION
- Allow tags to be used with -b
- Add --repo-branch option
- Add the Codex repo, with special treatment for its build step and for -b latest-release
- Rewrite the Codex tests to point to the Codex sandbox
- Change Codex's priority to 1, so that it runs more often

To test, run:
./pixel.js reference -g codex -b latest-release
./pixel.js test -g codex

Bug: T357185