### PR TITLE
Temporarily drop priority of wikiLambda

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -158,7 +158,7 @@ const GROUP_CONFIG = {
 		config: 'configCodex.js'
 	},
 	wikilambda: {
-		priority: 2,
+		priority: 4,
 		config: 'configWikiLambda.js'
 	}
 };


### PR DESCRIPTION
This seems to be introducing a fatal to other jobs:

SCENARIO > Special:CreateZObject (#vector-2022)
https://gist.github.com/jdlrobson/35d0618949a658fbe9567d623f85f10f