### PR TITLE
Update Node from v16 to v18

### DIFF
--- a/Dockerfile.a11y-regression
+++ b/Dockerfile.a11y-regression
@@ -1,4 +1,4 @@
-FROM node:16.15.1-bullseye
+FROM node:18.19.1-bullseye
 
 ARG PA11Y_VERSION
 

--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -2,7 +2,7 @@ FROM docker-registry.wikimedia.org/dev/buster-php74-fpm:1.0.0-s3
 
 COPY node-preparation.sh /node-preparation.sh
 
-RUN /node-preparation.sh ensure_node_major_version_installed 16 || \
+RUN /node-preparation.sh ensure_node_major_version_installed 18 || \
     (echo "Failed to install Node" && exit 1)
 
 WORKDIR /var/www/html/w

--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -1,4 +1,4 @@
-FROM node:16.15.1-bullseye
+FROM node:18.19.1-bullseye
 
 ARG BACKSTOPJS_VERSION
 


### PR DESCRIPTION
I saw the Node "required version" warnings when spinning Pixel up locally. I'm unsure if it's too early to update to Node 18 🤔, but thought I'd put up a PR for when we are ready

Will perhaps need to run `./pixel.js clean` and `./pixel.js reference` again after this is merged?

