### PR TITLE
Lossless PNGs optimization upon their appearance in "report" and its subdirectories

### DIFF
--- a/Dockerfile.optimizePNG
+++ b/Dockerfile.optimizePNG
@@ -1,7 +1,7 @@
 FROM alpine
 
 COPY optimizePNG.sh /opt/scripts/optimizePNG.sh
-COPY optimizePNG_supervisord.conf /ect/optimizePNG_supervisord.conf
+COPY optimizePNG_supervisord.conf /etc/optimizePNG_supervisord.conf
 
 WORKDIR /pixel/report
 

--- a/Dockerfile.optimizePNG
+++ b/Dockerfile.optimizePNG
@@ -1,0 +1,10 @@
+FROM alpine
+
+COPY optimizePNG.sh /opt/scripts/optimizePNG.sh
+COPY optimizePNG_supervisord.conf /ect/optimizePNG_supervisord.conf
+
+WORKDIR /pixel/report
+
+RUN apk add --no-cache supervisor inotify-tools optipng exiftool bash
+
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/optimizePNG_supervisord.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,4 +104,5 @@ services:
     volumes:
       - ./report:/pixel/report
       - ./optimizePNG.sh:/opt/scripts/optimizePNG.sh
+      - ./optimizePNG_supervisord.conf:/ect/optimizePNG_supervisord.conf
     working_dir: /pixel/report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,5 +104,5 @@ services:
     volumes:
       - ./report:/pixel/report
       - ./optimizePNG.sh:/opt/scripts/optimizePNG.sh
-      - ./optimizePNG_supervisord.conf:/ect/optimizePNG_supervisord.conf
+      - ./optimizePNG_supervisord.conf:/etc/optimizePNG_supervisord.conf
     working_dir: /pixel/report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,3 +97,11 @@ services:
       - ./configMobileA11y.js:/pixel/configMobileA11y.js
       - ./src:/pixel/src
       - ./report:/pixel/report
+  png-optimizer:
+    build:
+      context: .
+      dockerfile: Dockerfile.optimizePNG
+    volumes:
+      - ./report:/pixel/report
+      - ./optimizePNG.sh:/opt/scripts/optimizePNG.sh
+    working_dir: /pixel/report

--- a/optimizePNG.sh
+++ b/optimizePNG.sh
@@ -73,7 +73,7 @@ optimize_png() {
   remove_lock_file "$LOCK_FILE"
 }
 
-monitor_dir_and_optimize_pngs_upon_creation() {
+monitor_dir_optimizing_pngs_upon_creation() {
   local DIR
   DIR=$1
   local FILE_LOWER
@@ -98,4 +98,4 @@ ensure_dependencies_present() {
 
 ensure_dependencies_present
 
-monitor_dir_and_optimize_pngs_upon_creation "$DIR_TO_MONITOR"
+monitor_dir_optimizing_pngs_upon_creation"$DIR_TO_MONITOR"

--- a/optimizePNG.sh
+++ b/optimizePNG.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+DIR_TO_MONITOR="/pixel/report"
+
+OPTIMIZATION_TAG="OptimizedWithOptiPNG"
+
+ENABLE_DEBUG_LOGGING=0
+
+debug_log() {
+    if [ "$ENABLE_DEBUG_LOGGING" -ne 1 ]; then
+        return
+    fi
+    echo "$(date +"%Y-%m-%d %H:%M:%S") - $1"
+}
+
+remove_lock_file() {
+    local LOCK_FILE
+    LOCK_FILE=$1
+    if [ -f "$LOCK_FILE" ]; then
+        rm -f "$LOCK_FILE" || true
+    fi
+}
+
+optimize_png() {
+    sleep 1
+
+    local FILE
+    FILE=$1
+
+    if exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
+        debug_log "$FILE already optimized, skipping"
+        return
+    fi
+
+    # Replace '/' with '_' in the file path to create a unique lock file name
+    local LOCK_FILE
+    LOCK_FILE="/tmp/$(echo "$FILE" | sed 's/\//_/g').lock"
+
+    if [ -f "$LOCK_FILE" ]; then
+        debug_log "$FILE already being processed, skipping"
+        return
+    fi
+
+    touch "$LOCK_FILE"
+
+    local SIZE_BEFORE
+    SIZE_BEFORE=$(stat -c%s "$FILE")
+
+    optipng -silent -fix -o2 "$FILE"
+
+    exiftool -quiet -overwrite_original_in_place -Software="$OPTIMIZATION_TAG" "$FILE"
+
+    if ! exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
+        debug_log "$FILE failed to write processed flag"
+        remove_lock_file "$LOCK_FILE"
+        return
+    fi
+
+    local SIZE_AFTER
+    SIZE_AFTER=$(stat -c%s "$FILE")
+
+    local SIZE_REDUCTION
+    SIZE_REDUCTION=$((SIZE_BEFORE - SIZE_AFTER))
+    local SIZE_PERCENT_REDUCTION
+    if [ "$SIZE_BEFORE" -ne 0 ]; then
+        SIZE_PERCENT_REDUCTION=$(echo "scale=2; ($SIZE_REDUCTION / $SIZE_BEFORE) * 100" | bc)
+    else
+        SIZE_PERCENT_REDUCTION=0
+    fi
+
+    echo "$FILE optimized: Size reduction = $SIZE_PERCENT_REDUCTION%"
+
+    remove_lock_file "$LOCK_FILE"
+}
+
+monitor_dir_and_optimize_pngs_upon_creation() {
+  local DIR
+  DIR=$1
+  local FILE_LOWER
+  while true; do
+      inotifywait -r -m -e create --format '%w%f' "$DIR" | while read FILE
+      do
+          FILE_LOWER=$(echo "$FILE" | tr '[:upper:]' '[:lower:]')
+          if [[ "$FILE_LOWER" =~ \.png$ ]]; then
+              optimize_png "$FILE" &
+          fi
+      done
+  done
+}
+
+ensure_dependencies_present() {
+  if ! command -v inotifywait &> /dev/null || ! command -v optipng &> /dev/null || ! command -v exiftool &> /dev/null; then
+      debug_log "Required tools are missing. Please install inotify-tools, optipng, and exiftool."
+      exit 1
+  fi
+}
+
+ensure_dependencies_present
+
+monitor_dir_and_optimize_pngs_upon_creation "$DIR_TO_MONITOR"

--- a/optimizePNG.sh
+++ b/optimizePNG.sh
@@ -7,70 +7,70 @@ OPTIMIZATION_TAG="OptimizedWithOptiPNG"
 ENABLE_DEBUG_LOGGING=0
 
 debug_log() {
-    if [ "$ENABLE_DEBUG_LOGGING" -ne 1 ]; then
-        return
-    fi
-    echo "$(date +"%Y-%m-%d %H:%M:%S") - $1"
+  if [ "$ENABLE_DEBUG_LOGGING" -ne 1 ]; then
+    return
+  fi
+  echo "$(date +"%Y-%m-%d %H:%M:%S") - $1"
 }
 
 remove_lock_file() {
-    local LOCK_FILE
-    LOCK_FILE=$1
-    if [ -f "$LOCK_FILE" ]; then
-        rm -f "$LOCK_FILE" || true
-    fi
+  local LOCK_FILE
+  LOCK_FILE=$1
+  if [ -f "$LOCK_FILE" ]; then
+    rm -f "$LOCK_FILE" || true
+  fi
 }
 
 optimize_png() {
-    sleep 1
+  sleep 1
 
-    local FILE
-    FILE=$1
+  local FILE
+  FILE=$1
 
-    if exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
-        debug_log "$FILE already optimized, skipping"
-        return
-    fi
+  if exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
+    debug_log "$FILE already optimized, skipping"
+    return
+  fi
 
-    # Replace '/' with '_' in the file path to create a unique lock file name
-    local LOCK_FILE
-    LOCK_FILE="/tmp/$(echo "$FILE" | sed 's/\//_/g').lock"
+  # Replace '/' with '_' in the file path to create a unique lock file name
+  local LOCK_FILE
+  LOCK_FILE="/tmp/$(echo "$FILE" | sed 's/\//_/g').lock"
 
-    if [ -f "$LOCK_FILE" ]; then
-        debug_log "$FILE already being processed, skipping"
-        return
-    fi
+  if [ -f "$LOCK_FILE" ]; then
+    debug_log "$FILE already being processed, skipping"
+    return
+  fi
 
-    touch "$LOCK_FILE"
+  touch "$LOCK_FILE"
 
-    local SIZE_BEFORE
-    SIZE_BEFORE=$(stat -c%s "$FILE")
+  local SIZE_BEFORE
+  SIZE_BEFORE=$(stat -c%s "$FILE")
 
-    optipng -silent -fix -o2 "$FILE"
+  optipng -silent -fix -o2 "$FILE"
 
-    exiftool -quiet -overwrite_original_in_place -Software="$OPTIMIZATION_TAG" "$FILE"
+  exiftool -quiet -overwrite_original_in_place -Software="$OPTIMIZATION_TAG" "$FILE"
 
-    if ! exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
-        debug_log "$FILE failed to write processed flag"
-        remove_lock_file "$LOCK_FILE"
-        return
-    fi
-
-    local SIZE_AFTER
-    SIZE_AFTER=$(stat -c%s "$FILE")
-
-    local SIZE_REDUCTION
-    SIZE_REDUCTION=$((SIZE_BEFORE - SIZE_AFTER))
-    local SIZE_PERCENT_REDUCTION
-    if [ "$SIZE_BEFORE" -ne 0 ]; then
-        SIZE_PERCENT_REDUCTION=$(echo "scale=2; ($SIZE_REDUCTION / $SIZE_BEFORE) * 100" | bc)
-    else
-        SIZE_PERCENT_REDUCTION=0
-    fi
-
-    echo "$FILE optimized: Size reduction = $SIZE_PERCENT_REDUCTION%"
-
+  if ! exiftool -quiet -Software "$FILE" | grep -q "$OPTIMIZATION_TAG"; then
+    debug_log "$FILE failed to write processed flag"
     remove_lock_file "$LOCK_FILE"
+    return
+  fi
+
+  local SIZE_AFTER
+  SIZE_AFTER=$(stat -c%s "$FILE")
+
+  local SIZE_REDUCTION
+  SIZE_REDUCTION=$((SIZE_BEFORE - SIZE_AFTER))
+  local SIZE_PERCENT_REDUCTION
+  if [ "$SIZE_BEFORE" -ne 0 ]; then
+    SIZE_PERCENT_REDUCTION=$(echo "scale=2; ($SIZE_REDUCTION / $SIZE_BEFORE) * 100" | bc)
+  else
+    SIZE_PERCENT_REDUCTION=0
+  fi
+
+  echo "$FILE optimized: Size reduction = $SIZE_PERCENT_REDUCTION%"
+
+  remove_lock_file "$LOCK_FILE"
 }
 
 monitor_dir_and_optimize_pngs_upon_creation() {
@@ -78,22 +78,21 @@ monitor_dir_and_optimize_pngs_upon_creation() {
   DIR=$1
   local FILE_LOWER
   while true; do
-      inotifywait -r -m -e create --format '%w%f' "$DIR" | while read FILE
-      do
-          FILE_LOWER=$(echo "$FILE" | tr '[:upper:]' '[:lower:]')
-          if [[ "$FILE_LOWER" =~ \.png$ ]]; then
-              optimize_png "$FILE" &
-          fi
-      done
+    inotifywait -r -m -e create --format '%w%f' "$DIR" | while read FILE; do
+      FILE_LOWER=$(echo "$FILE" | tr '[:upper:]' '[:lower:]')
+      if [[ "$FILE_LOWER" =~ \.png$ ]]; then
+        optimize_png "$FILE" &
+      fi
+    done
   done
 }
 
 ensure_dependencies_present() {
-  if ! command -v inotifywait &> /dev/null || 
-     ! command -v optipng &> /dev/null || 
-     ! command -v exiftool &> /dev/null; then
-      debug_log "Required tools are missing. The Dockerfile should install inotify-tools, optipng, and exiftool."
-      exit 1
+  if ! command -v inotifywait &>/dev/null ||
+    ! command -v optipng &>/dev/null ||
+    ! command -v exiftool &>/dev/null; then
+    debug_log "Required tools are missing. The Dockerfile should install inotify-tools, optipng, and exiftool."
+    exit 1
   fi
 }
 

--- a/optimizePNG.sh
+++ b/optimizePNG.sh
@@ -89,8 +89,10 @@ monitor_dir_and_optimize_pngs_upon_creation() {
 }
 
 ensure_dependencies_present() {
-  if ! command -v inotifywait &> /dev/null || ! command -v optipng &> /dev/null || ! command -v exiftool &> /dev/null; then
-      debug_log "Required tools are missing. Please install inotify-tools, optipng, and exiftool."
+  if ! command -v inotifywait &> /dev/null || 
+     ! command -v optipng &> /dev/null || 
+     ! command -v exiftool &> /dev/null; then
+      debug_log "Required tools are missing. The Dockerfile should install inotify-tools, optipng, and exiftool."
       exit 1
   fi
 }

--- a/optimizePNG_supervisord.conf
+++ b/optimizePNG_supervisord.conf
@@ -1,0 +1,6 @@
+[supervisord]
+nodaemon=true
+
+[program:optimizer]
+command=/bin/sh -c "/opt/scripts/optimizePNG.sh"
+autorestart=true

--- a/optimizePNG_supervisord.conf
+++ b/optimizePNG_supervisord.conf
@@ -1,6 +1,8 @@
 [supervisord]
 nodaemon=true
 user=root
+logfile=/var/log/supervisord.log
+pidfile=/var/run/supervisord.pid
 
 [program:optimizer]
 command=/bin/sh -c "/opt/scripts/optimizePNG.sh"

--- a/optimizePNG_supervisord.conf
+++ b/optimizePNG_supervisord.conf
@@ -1,6 +1,11 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [program:optimizer]
 command=/bin/sh -c "/opt/scripts/optimizePNG.sh"
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
Reduces PNG file sizes by roughly 30%

Monitors "report" and its subdirectories - isn't otherwise coupled with Pixel code

Quick enough that it doesn't appear to interfere with the BackstopJS image comparison process - running it locally I haven't noticed any odd breakage

`Optipng` performs the optimization, "-o2" level seems a good balance between speed and file size reduction

Restarts itself if the process ever goes down