### PR TITLE
Simplify regression Dockerfiles

### DIFF
--- a/Dockerfile.a11y-regression
+++ b/Dockerfile.a11y-regression
@@ -1,4 +1,4 @@
-FROM node:18.19.1-bullseye
+FROM --platform=linux/amd64 node:18.19.1-bullseye
 
 ARG PA11Y_VERSION
 
@@ -10,34 +10,10 @@ RUN apt-get update && \
 	apt-get install -y git sudo software-properties-common
 
 RUN set -ex && \
-    DEBIAN_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f2 | tr -d '"') && \
-    export DEBIAN_VERSION=$DEBIAN_VERSION && \
-    ARCH=`uname -m` && \
-    if [ "$ARCH" = "x86_64" ]; then \
-       sudo npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION}; \
-    else \
-       sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION} puppeteer@21.7.0 puppeteer-chromium-version-finder@^1.0.1 chromium-version-deb-finder@^2.0.1 && \
-       NODE_PATH="$(npm root -g):$(npm root -g)/puppeteer/node_modules" node -e " \
-          const versionFinder = require('puppeteer-chromium-version-finder'); \
-          const debFinder = require('chromium-version-deb-finder'); \
-          (async () => { \
-            const version = await versionFinder.getPuppeteerChromiumVersion(); \
-            const debUrls = await debFinder.getDebUrlsForVersionAndArch(version.MAJOR, version.MINOR, process.env.DEBIAN_VERSION, 'arm64'); \
-            console.log(debUrls.join('\n')); \
-          })(); \
-       " | \
-       xargs -I % sh -c 'set -x; echo "Downloading: %"; wget -c -t 10 -w 10 -T 120 %; echo "Downloaded: %"' && \
-       apt install -y ./*.deb && \
-       rm -f ./*.deb && \
-       sudo test -f /usr/bin/chromium && sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser && sudo ln -s /usr/bin/chromium /usr/bin/chrome; \
-    fi
+    sudo npm install -g --unsafe-perm=true --allow-root pa11y@${PA11Y_VERSION};
 
-RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
-RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
-
-RUN apt-get -qqy update \
-  && apt-get -qqy --no-install-recommends install \
-    libxshmfence-dev \
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
     libfontconfig \
     libfreetype6 \
     xfonts-cyrillic \
@@ -46,14 +22,55 @@ RUN apt-get -qqy update \
     fonts-ipafont-gothic \
     fonts-wqy-zenhei \
     libgbm-dev \
-    gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget \
+    gconf-service \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgcc1 \
+    libgconf-2-4 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxss1 \
+    libxtst6 \
+    libappindicator1 \
+    libnss3 \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    ca-certificates \
+    lsb-release \
+    xdg-utils \
+    wget \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libgbm1 \
+    libxkbcommon0 \
+    procps \
+    tree \
   && rm -rf /var/lib/apt/lists/* \
-  && apt-get -qyy clean
+  && apt-get clean -qy
 
 RUN sudo npm install -g mustache
 RUN sudo npm install -g node-fetch@2
 
 ENV NODE_PATH=/usr/local/lib/node_modules
 
-#ENTRYPOINT ["tail", "-f", "/dev/null"]
 ENTRYPOINT ["node", "src/a11y/runA11yTests.js"]

--- a/Dockerfile.a11y-regression
+++ b/Dockerfile.a11y-regression
@@ -1,4 +1,4 @@
-FROM node:16.15.1-bullseye
+FROM node:18.19.1-bullseye
 
 ARG PA11Y_VERSION
 

--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -2,7 +2,7 @@ FROM docker-registry.wikimedia.org/dev/buster-php74-fpm:1.0.0-s3
 
 COPY node-preparation.sh /node-preparation.sh
 
-RUN /node-preparation.sh ensure_node_major_version_installed 16 || \
+RUN /node-preparation.sh ensure_node_major_version_installed 18 || \
     (echo "Failed to install Node" && exit 1)
 
 WORKDIR /var/www/html/w

--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -1,4 +1,4 @@
-FROM node:16.15.1-bullseye
+FROM node:18.19.1-bullseye
 
 ARG BACKSTOPJS_VERSION
 

--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -1,4 +1,4 @@
-FROM node:18.19.1-bullseye
+FROM --platform=linux/amd64 node:18.19.1-bullseye
 
 ARG BACKSTOPJS_VERSION
 
@@ -10,39 +10,10 @@ RUN apt-get update && \
 	apt-get install -y git sudo software-properties-common
 
 RUN set -ex && \
-    DEBIAN_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f2 | tr -d '"') && \
-    export DEBIAN_VERSION=$DEBIAN_VERSION && \
-    ARCH=`uname -m` && \
-    if [ "$ARCH" = "x86_64" ]; then \
-       sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}; \
-    else \
-       sudo PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION} puppeteer-chromium-version-finder@^1.0.1 chromium-version-deb-finder@^2.0.1 && \
-       NODE_PATH="$(npm root -g):$(npm root -g)/backstopjs/node_modules" node -e " \
-          const versionFinder = require('puppeteer-chromium-version-finder'); \
-          const debFinder = require('chromium-version-deb-finder'); \
-          (async () => { \
-            const version = await versionFinder.getPuppeteerChromiumVersion(); \
-            const debUrls = await debFinder.getDebUrlsForVersionAndArch(version.MAJOR, version.MINOR, process.env.DEBIAN_VERSION, 'arm64'); \
-            console.log(debUrls.join('\n')); \
-          })(); \
-       " | \
-       xargs -I % sh -c 'set -x; echo "Downloading: %"; wget -c -t 10 -w 10 -T 120 %; echo "Downloaded: %"' && \
-       apt install -y ./*.deb && \
-       rm -f ./*.deb && \
-       sudo test -f /usr/bin/chromium && sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser && sudo ln -s /usr/bin/chromium /usr/bin/chrome; \
-    fi
+    sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION};
 
-RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
-RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
-
-# RUN apt-get -y update && apt-get -y install google-chrome-stable
-
-# RUN apt-get install -y firefox-esr
-
-# gconf-service libxext6.... added for https://github.com/garris/BackstopJS/issues/1225
-
-RUN apt-get -qqy update \
-  && apt-get -qqy --no-install-recommends install \
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
     libfontconfig \
     libfreetype6 \
     xfonts-cyrillic \
@@ -51,9 +22,51 @@ RUN apt-get -qqy update \
     fonts-ipafont-gothic \
     fonts-wqy-zenhei \
     libgbm-dev \
-    gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget \
+    gconf-service \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgcc1 \
+    libgconf-2-4 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxss1 \
+    libxtst6 \
+    libappindicator1 \
+    libnss3 \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    ca-certificates \
+    lsb-release \
+    xdg-utils \
+    wget \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libgbm1 \
+    libxkbcommon0 \
+    procps \
+    tree \
   && rm -rf /var/lib/apt/lists/* \
-  && apt-get -qyy clean
+  && apt-get clean -qy
 
 WORKDIR /src
 


### PR DESCRIPTION
Based on https://github.com/wikimedia/pixel/pull/251

- vastly simplified Dockerfile.a11y-regression and Dockerfile.visual-regression
- preserves ability to run locally on ARM macOS machines
- on macOS drastically speeds up Docker builds for these two images as it no longer has to fetch and install Chromium .deb files