### PR TITLE
Do not open files when we run in a non interactive environment.

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -569,7 +569,9 @@ Skipping group "${groupName}" due to priority.
 				}
 			}
 			const path = await makeReport( outputDir, html );
-			await batchSpawn.spawn( 'open', [ path ] );
+			if ( !process.env.NONINTERACTIVE ) {
+				await batchSpawn.spawn( 'open', [ path ] );
+			}
 		} );
 	program.parse();
 }


### PR DESCRIPTION
Running on the pixel server, this causes errors (we cannot open the result in the browser).