### PR TITLE
More aggressively remove Docker artifacts on clean

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -31,6 +31,7 @@ function getComposeOpts( opts ) {
  */
 async function cleanCommand() {
 	await batchSpawn.spawn( 'docker', [ 'compose', ...getComposeOpts( [ 'down', '--rmi', 'all', '--volumes', '--remove-orphans' ] ) ] );
+	await batchSpawn.spawn( 'docker', [ 'system', 'prune', '-af' ] );
 }
 
 let context;


### PR DESCRIPTION
Should help free up space 

Currently the cron runs `pixel.js clean`, which calls this, at 08:00 daily

Can also manually invoke it on the server to free up space too:

`cd /srv/pixel/ && node pixel.js clean`

When you run the command above you can also use the following in a separate ssh session to the server to watch the effect on free disk space in the relevant docker folders:

`while true; do clear && du -h /var/lib/docker --max-depth=1 | sort -hr; sleep 5; done`

https://phabricator.wikimedia.org/T361331#9672202