### PR TITLE
Log error

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -332,6 +332,7 @@ async function processCommand( type, opts, runSilently = false ) {
 					type, group, config.paths.html_report, runSilently || process.env.NONINTERACTIVE
 				);
 			}, async ( /** @type {Error} */ err ) => {
+				console.error( err );
 				// Don't check error message if caller asked us not to.
 				if ( err.message.includes( '130' ) ) {
 					// If user ends subprocess with a sigint, exit early.


### PR DESCRIPTION
The pixel.log file is ending abruptly sometimes and I think it could be related to the process.exit calls in this error handler. Adding this to perhaps get some details