### PR TITLE
Add Git tag/information to the report output.

### DIFF
--- a/src/makeReportIndex.js
+++ b/src/makeReportIndex.js
@@ -1,12 +1,25 @@
 const fs = require( 'fs' );
+const util = require( 'util' );
+const exec = util.promisify( require( 'child_process' ).exec );
+
+/**
+ * Get information about the current git tag
+ *
+ * @return {Promise<string>} - the tag/commit information
+ */
+async function getGitTagInformation() {
+	const { stdout } = await exec( 'git describe --tags' );
+	return stdout;
+}
 
 /**
  *
  * @param {string} directory
  * @param {string} html
- * @return {string}
+ * @return {Promise<string>}
  */
-function makeReport( directory, html ) {
+async function makeReport( directory, html ) {
+	const gitInformation = await getGitTagInformation();
 	const docHTML = `<!DOCTYPE HTML>
 <html>
 	<head>
@@ -17,6 +30,7 @@ function makeReport( directory, html ) {
 		<h1>UI regression reports</h1>
 		<p>This page is automatically updated by the command: <pre>node pixel.js runAll</pre></p>
 		<p>Page was last generated on: ${new Date()}</p>
+		<p>Using Pixel ${gitInformation}</p>
 		<h2>Available reports</h2>
 		<ul>
 			${html}


### PR DESCRIPTION
This will help us to keep track of which version that runs on the new production server. Running this locally, it will output the latest tag + commits since that tag.

![version-info](https://github.com/wikimedia/pixel/assets/540757/aa4ae6d8-118b-4815-acc5-6f713ce77fe3)
