### PR TITLE
Fix WikiLambda, speeds up php dependency installs

### DIFF
--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -9,7 +9,6 @@ COPY node-preparation.sh /node-preparation.sh
 COPY src/BatchSpawn.js /src/BatchSpawn.js
 COPY src/setupRepos.sh /src/setupRepos.sh
 COPY repositories.json /repositories.json
-COPY composer.local.json composer.local.json
 
 WORKDIR /var/www/html/w
 

--- a/composer.local.json
+++ b/composer.local.json
@@ -1,9 +1,0 @@
-{
-	"extra": {
-		"merge-plugin": {
-			"include": [
-				"extensions/WikiLambda/composer.json"
-			]
-		}
-	}
-}

--- a/src/setupRepos.sh
+++ b/src/setupRepos.sh
@@ -45,14 +45,6 @@ setup_repo() {
     exit 1
   fi
   git -C "${path}" checkout --progress "$(get_default_branch "$path")"
-  if [ -e "$(pwd)/${path}/composer.json" ]; then
-    echo -e "\nRunning composer install for $path..."
-    local composer_output=$(composer install --working-dir="${path}" --no-dev -n 2>&1) || {
-      echo -e "${id} Composer install failed with output:\n${composer_output}"
-      exit 1
-    }
-    echo -e "\e[32mSuccess!\e[0m"
-  fi
   if [ -e "${path}/.gitmodules" ]; then
     echo "Git submodule update: ${path}"
     git -C "${path}" submodule update --init
@@ -69,7 +61,12 @@ setup_core() {
     exit 1
   fi
   git checkout --progress "$(get_default_branch ".")"
-  echo -e "\nRunning composer install for Mediawiki Core..."
+  echo -e "\e[32mSuccess!\e[0m"
+}
+
+install_php_dependencies() {
+  echo -e "\nRunning composer install for Mediawiki Core, extensions and skins..."
+  mv ./composer.local.json-sample ./composer.local.json
   local composer_output=$(composer install --no-dev -n 2>&1) || {
     echo -e "Mediawiki Core Composer install failed with output:\n${composer_output}"
     exit 1
@@ -94,6 +91,8 @@ start_time=$(date +%s)
 setup_core
 sleep 1
 setup_repos
+sleep 1
+install_php_dependencies
 
 end_time=$(date +%s)
 


### PR DESCRIPTION
Noticed WikiLambda wasn't working

Was a php dependency installation issue

This PR speeds up mediawiki docker image build quite a bit by doing a single `composer install` for core, extensions and skins (formerly composer install was called for core and each extension)

Works because the `composer.local.json-sample` file contains this:

```
{
	"extra": {
		"merge-plugin": {
			"include": [
				"extensions/*/composer.json",
				"skins/*/composer.json"
			]
		}
	}
}
```