### PR TITLE
Add config that applies CSS from WikimediaMessages

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -388,3 +388,6 @@ $wgVectorLanguageAlertInSidebar = [
 
 $wgMFAmcOutreachMinEditCount = 0;
 $wgMFAmcOutreach = true;
+
+// Add CSS from the WikimediaMessages repo to the following skins.
+$wgWikimediaStylesSkins = [ "vector-2022", "minerva" ];


### PR DESCRIPTION
Adds configuration that applies CSS from the
WikimediaMessages repo to Minerva and Vector 2022

These styles improve the appearance of templates on mobile and reflect production config.

Bug: T363716