### PR TITLE
Switch auto-changelog to generate a PR

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-changelog:
@@ -29,10 +30,13 @@ jobs:
     - name: Generate changelog
       run: auto-changelog
 
-    - name: Commit and push changes
-      run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "GitHub Action"
-        git add CHANGELOG.md
-        git commit -m "Update changelog"
-        git push origin HEAD:main
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: Update changelog
+        title: Update Changelog
+        body: Auto-generated pull request to update the changelog
+        branch: update-changelog
+        base: main
+        delete-branch: true


### PR DESCRIPTION
Switch auto-changelog to generate a PR instead of adding a commit (when we push a version tag)