### PR TITLE
DRY some config bits, use '--single-process' for speedup, use 'asyncCaptureLimit=8'

### DIFF
--- a/config/configCampaignEvents.js
+++ b/config/configCampaignEvents.js
@@ -1,4 +1,5 @@
 const BASE_URL = process.env.PIXEL_MW_SERVER;
+const configCommon = require( './configCommon' );
 const utils = require( '../utils' );
 const {
 	VIEWPORT_PHONE,
@@ -62,7 +63,7 @@ const scenarios = tests.map( ( test ) => {
 } );
 
 module.exports = {
-	id: 'MediaWiki',
+	...configCommon,
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
@@ -70,20 +71,6 @@ module.exports = {
 		VIEWPORT_DESKTOP_WIDE,
 		VIEWPORT_DESKTOP_WIDEST
 	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
 	scenarios,
-	paths: utils.makePaths( 'campaign-events' ),
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		headless: 'new',
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 10,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
+	paths: utils.makePaths( 'campaign-events' )
 };

--- a/config/configCodex.js
+++ b/config/configCodex.js
@@ -1,4 +1,5 @@
 const utils = require( '../utils' );
+const configCommon = require( './configCommon' );
 const {
 	VIEWPORT_PHONE,
 	VIEWPORT_TABLET,
@@ -142,24 +143,12 @@ const scenarios = components.map( ( componentData ) => {
 } );
 
 module.exports = {
-	id: 'MediaWiki',
+	...configCommon,
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
 		VIEWPORT_DESKTOP
 	],
 	scenarios,
-	paths: utils.makePaths( 'codex' ),
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		headless: 'new',
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 10,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
+	paths: utils.makePaths( 'codex' )
 };

--- a/config/configCommon.js
+++ b/config/configCommon.js
@@ -7,7 +7,8 @@ module.exports = {
 	engineOptions: {
 		headless: 'new',
 		args: [
-			'--no-sandbox'
+			'--no-sandbox',
+			'--single-process'
 		]
 	},
 	debug: false,

--- a/config/configCommon.js
+++ b/config/configCommon.js
@@ -1,6 +1,6 @@
 module.exports = {
 	id: 'MediaWiki',
-	asyncCaptureLimit: 10,
+	asyncCaptureLimit: 8,
 	onBeforeScript: 'puppet/onBefore.js',
 	onReadyScript: 'puppet/onReady.js',
 	engine: 'puppeteer',

--- a/config/configCommon.js
+++ b/config/configCommon.js
@@ -1,0 +1,15 @@
+module.exports = {
+	id: 'MediaWiki',
+	asyncCaptureLimit: 10,
+	onBeforeScript: 'puppet/onBefore.js',
+	onReadyScript: 'puppet/onReady.js',
+	engine: 'puppeteer',
+	engineOptions: {
+		headless: 'new',
+		args: [
+			'--no-sandbox'
+		]
+	},
+	debug: false,
+	debugWindow: false
+};

--- a/config/configDesktop.js
+++ b/config/configDesktop.js
@@ -1,4 +1,5 @@
 const BASE_URL = process.env.PIXEL_MW_SERVER;
+const configCommon = require( './configCommon' );
 const utils = require( '../utils' );
 const {
 	VIEWPORT_PHONE,
@@ -251,7 +252,7 @@ const scenarios = tests.map( ( test ) => {
 } );
 
 module.exports = {
-	id: 'MediaWiki',
+	...configCommon,
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
@@ -259,20 +260,6 @@ module.exports = {
 		VIEWPORT_DESKTOP_WIDE,
 		VIEWPORT_DESKTOP_WIDEST
 	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
 	scenarios,
-	paths: utils.makePaths( 'desktop' ),
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		headless: 'new',
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 10,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
+	paths: utils.makePaths( 'desktop' )
 };

--- a/config/configLogin.js
+++ b/config/configLogin.js
@@ -1,4 +1,5 @@
 const utils = require( '../utils' );
+const configCommon = require( './configCommon' );
 
 const {
 	VIEWPORT_PHONE,
@@ -38,7 +39,7 @@ const scenarios = utils.makeScenariosForSkins( [
 } ) );
 
 module.exports = {
-	id: 'MediaWiki',
+	...configCommon,
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
@@ -46,20 +47,6 @@ module.exports = {
 		VIEWPORT_DESKTOP_WIDE,
 		VIEWPORT_DESKTOP_WIDEST
 	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
 	scenarios,
-	paths: utils.makePaths( 'login' ),
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		headless: 'new',
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 10,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
+	paths: utils.makePaths( 'login' )
 };

--- a/config/configWikiLambda.js
+++ b/config/configWikiLambda.js
@@ -1,4 +1,5 @@
 const BASE_URL = process.env.PIXEL_MW_SERVER;
+const configCommon = require( './configCommon' );
 const utils = require( '../utils' );
 const {
 	VIEWPORT_PHONE,
@@ -68,7 +69,7 @@ const scenarios = tests.map( ( test ) => {
 } );
 
 module.exports = {
-	id: 'MediaWiki',
+	...configCommon,
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,
@@ -76,20 +77,6 @@ module.exports = {
 		VIEWPORT_DESKTOP_WIDE,
 		VIEWPORT_DESKTOP_WIDEST
 	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
 	scenarios,
-	paths: utils.makePaths( 'wikilambda' ),
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		headless: 'new',
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 10,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
+	paths: utils.makePaths( 'wikilambda' )
 };


### PR DESCRIPTION
Config DRYing:

- Moves common config bits to a separate file
Makes it easier to make config changes which apply to all configurations

Config changes:

- Reduces async limit to 8
Think of this limit as the number of headless Chrome instances being driven simultaneous. There's a point of diminishing returns with having this number much above the number of processors, or so high that available memory is pressured. May even reduce this more after more benchmarking

- Uses --single-process
Runs everything in a single process, which can improve performance by reducing inter-process communication overhead. Benchmarking on my machine this speeds things up by about 30%. On my machine, running runAll with priority 1, with only the first 25 tests in the desktop config, averaged across 5 runs:
**without** `--single-process`: 563 seconds
**with** `--single-process`: 386 seconds