### PR TITLE
Reset the db before runs

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -160,9 +160,9 @@ async function processCommand( type, opts, runSilently = false ) {
 		updateContext( group, type, activeBranch, description );
 
 		await prepareDockerEnvironment( opts );
-		const { stdout: stdout1 } = await simpleSpawn.exec( './reset-db.sh' );
+		const { stdout: stdout1 } = await simpleSpawn.exec( './purgeParserCache.sh' );
 		console.log( stdout1 );
-		const { stdout: stdout2 } = await simpleSpawn.exec( './purgeParserCache.sh' );
+		const { stdout: stdout2 } = await simpleSpawn.exec( './reset-db.sh' );
 		console.log( stdout2 );
 
 		if ( opts.a11y ) {

--- a/pixel.js
+++ b/pixel.js
@@ -224,6 +224,8 @@ function updateContext( group, type, activeBranch, description ) {
 async function prepareDockerEnvironment( opts ) {
 	await simpleSpawn.spawn( './build-base-regression-image.sh' );
 	await simpleSpawn.spawn( './start.sh' );
+	const { stdout } = await simpleSpawn.exec( './reset-db.sh' );
+	console.log( stdout );
 	await simpleSpawn.spawn(
 		'docker',
 		[ 'compose', ...getComposeOpts( [ 'exec', ...( process.env.NONINTERACTIVE ? [ '-T' ] : [] ), 'mediawiki', '/src/main.js', JSON.stringify( opts ) ] ) ]

--- a/pixel.js
+++ b/pixel.js
@@ -160,8 +160,10 @@ async function processCommand( type, opts, runSilently = false ) {
 		updateContext( group, type, activeBranch, description );
 
 		await prepareDockerEnvironment( opts );
-		const { stdout } = await simpleSpawn.exec( './purgeParserCache.sh' );
-		console.log( stdout );
+		const { stdout: stdout1 } = await simpleSpawn.exec( './reset-db.sh' );
+		console.log( stdout1 );
+		const { stdout: stdout2 } = await simpleSpawn.exec( './purgeParserCache.sh' );
+		console.log( stdout2 );
 
 		if ( opts.a11y ) {
 			return await runA11yRegressionTests( type, configFile, opts.logResults, opts );
@@ -224,8 +226,6 @@ function updateContext( group, type, activeBranch, description ) {
 async function prepareDockerEnvironment( opts ) {
 	await simpleSpawn.spawn( './build-base-regression-image.sh' );
 	await simpleSpawn.spawn( './start.sh' );
-	const { stdout } = await simpleSpawn.exec( './reset-db.sh' );
-	console.log( stdout );
 	await simpleSpawn.spawn(
 		'docker',
 		[ 'compose', ...getComposeOpts( [ 'exec', ...( process.env.NONINTERACTIVE ? [ '-T' ] : [] ), 'mediawiki', '/src/main.js', JSON.stringify( opts ) ] ) ]


### PR DESCRIPTION
We were seeing this error:

![MediaWiki_Enable_Event_Registration_logged-in_0_main_4_desktop-widest](https://github.com/wikimedia/pixel/assets/3143487/8b638d3e-2935-4dad-a3d6-8a7a28d18ff4)

The issue was related to the [renaming of a table](https://phabricator.wikimedia.org/T346293)

The issue was seen when Pixel ran `reference`, then ran `test`, then ran `reference` again subsequently

I think this is because `test`, which runs on a newer commit, had the change, but then the next `reference` run was runs on older commits, didn't yet have them ( in the release reference uses )

The reset-db.sh script is quick and causes the schema to be as expected before each run

There's probably a more direct way to reset the db (we tried calling update.php in the mediawiki container) but reset-db.sh is really fast