### PR TITLE
Update base regression image to bookworm

### DIFF
--- a/Dockerfile.base-regression
+++ b/Dockerfile.base-regression
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18.19.1-bullseye-slim
+FROM --platform=linux/amd64 node:18.20.2-bookworm-slim
 
 # Base packages and Chrome dependencies
 RUN apt-get update -qq \
@@ -8,7 +8,6 @@ RUN apt-get update -qq \
     software-properties-common \
     libfontconfig \
     libfreetype6 \
-    xfonts-cyrillic \
     xfonts-scalable \
     fonts-dejavu \
     fonts-dejavu-core \


### PR DESCRIPTION
Attempt to fix occasional hard to reproduce dbus error

May need to run `./rebuild.sh` when using Pixel locally 