### PR TITLE
Add Codex-specific onReady script

### DIFF
--- a/config/configCodex.js
+++ b/config/configCodex.js
@@ -148,6 +148,7 @@ const scenarios = components.map( ( componentData ) => {
 
 module.exports = {
 	...configCommon,
+	onReadyScript: 'puppet/onReady-codex.js',
 	viewports: [
 		VIEWPORT_PHONE,
 		VIEWPORT_TABLET,

--- a/src/engine-scripts/puppet/onReady-codex.js
+++ b/src/engine-scripts/puppet/onReady-codex.js
@@ -1,0 +1,23 @@
+const waitForIdle = require( './waitForIdle' );
+
+/**
+ * @param {import('puppeteer').Page} page
+ * @param {import('backstopjs').Scenario} scenario
+ */
+module.exports = async ( page, scenario ) => {
+	console.log( 'SCENARIO > ' + scenario.label );
+
+	// Add CSS that disables all animations
+	await page.evaluate( () => {
+		const styleNode = document.createElement( 'style' );
+		// Technically this delays the start of all animations for 2 hours and 46 minutes,
+		// but our tests shouldn't take long enough for that to matter
+		styleNode.innerText = '* { animation-delay: 9999s !important; }';
+		document.head.appendChild( styleNode );
+	} );
+
+	// Wait for any images to finish loading.
+	await page.waitForNetworkIdle();
+	// Wait for the main thread to have an idle period.
+	await waitForIdle( page );
+};


### PR DESCRIPTION
The shared one in onReady.js doesn't work because it contains too many MW-specific things, and errors out if the global mw object doesn't exist (which it doesn't in the Codex sandbox).

Instead, use a simpler onReady script for Codex, that just prints the scenario name, waits for idle, and adds a CSS one-liner that disables animations (this fixes T361528).

Bug: T361528