### PR TITLE
Make Pixel smarter about needed Codex version (WIP)

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -163,18 +163,20 @@ function removeFolder( relativePath ) {
 }
 
 async function updateCodexRepoBranchIfNecessary( opts, mwBranch ) {
-	// If the user hasn't specified a '--repo-branch' for codex
-	// determine which version the MW branch wants and use it
-	if ( !opts.repoBranch?.some( ( branch ) => branch.startsWith( 'design/codex:' ) ) ) {
-		let codexVersion;
-		try {
-			codexVersion = await getCodexVersionForMWBranch( mwBranch );
-		} catch ( error ) {
-			codexVersion = await getLatestCodexVersion();
-			console.log( `\x1b[33m${error.message}Falling back to latest Codex version ${codexVersion}\x1b[0m` );
-		}
-		opts.repoBranch = [ ...( opts.repoBranch ?? [] ), `design/codex:${codexVersion}` ];
+	// Return if the user has already specified a '--repo-branch' for Codex
+	if ( opts.repoBranch?.some( ( branch ) => branch.startsWith( 'design/codex:' ) ) ) {
+		return;
 	}
+	// Determine which Codex version the MW branch wants and use it,
+	// fallback on latest version
+	let codexVersion;
+	try {
+		codexVersion = await getCodexVersionForMWBranch( mwBranch );
+	} catch ( error ) {
+		codexVersion = await getLatestCodexVersion();
+		console.log( `\x1b[33m${error.message}Falling back to latest Codex version ${codexVersion}\x1b[0m` );
+	}
+	opts.repoBranch = [ ...( opts.repoBranch ?? [] ), `design/codex:${codexVersion}` ];
 }
 
 /**


### PR DESCRIPTION
With this patch, if the user doesn't specify a Codex version to use via `--repo-branch`, the version of Codex _referenced in the MW branch in use_ is determined and used

Note: Couldn't use `git show` to get the file `foreign-resources.yaml` since initially the MW repo isn't yet cloned. Can always tweak later. I hope to further consolidate all fetching in one place later, at which point we can probably re-visit this