### PR TITLE
Add 1 test for Vector and Minerva night mode

### DIFF
--- a/config/configDesktop.js
+++ b/config/configDesktop.js
@@ -97,6 +97,13 @@ const tests = [
 		]
 	},
 	//
+	// NIGHT THEME
+	//
+	{
+		label: 'Night mode (#vector-2022, #logged-in, #toc-unpinned, #main-menu-unpinned, #page-tools-unpinned)',
+		path: '/wiki/Test?vectornightmode=1'
+	},
+	//
 	// TOC
 	//
 	{

--- a/config/configMobile.js
+++ b/config/configMobile.js
@@ -16,6 +16,10 @@ const tests = [
 		path: '/wiki/Test'
 	},
 	{
+		label: 'Test in night mode (#minerva #mobile)',
+		path: '/wiki/Test?minervanightmode=1'
+	},
+	{
 		label: 'Test (#minerva #mobile #logged-in)',
 		path: '/wiki/Test'
 	},


### PR DESCRIPTION
The main thing we care about is articles so I think one test should be sufficient for checking for major issues.

For other pages, I suspect these would be better done as acceptance criteria to fixing those pages. For example if and when night theme is supported on talk pages we would add a test as part of that task.

Bug: T363945