### PR TITLE
Hide user generated content from accessibility tests

### DIFF
--- a/config/configDesktopA11y.js
+++ b/config/configDesktopA11y.js
@@ -15,6 +15,7 @@ const testDefaults = {
 	],
 	includeWarnings: true,
 	includeNotices: true,
+	hideElements: '#bodyContent',
 	ignore: [
 		// Prevent contrast ratio error on absolutely positioned elements
 		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',

--- a/config/configDesktopA11y.js
+++ b/config/configDesktopA11y.js
@@ -15,7 +15,7 @@ const testDefaults = {
 	],
 	includeWarnings: true,
 	includeNotices: true,
-	hideElements: '#bodyContent',
+	hideElements: '.mw-body-content',
 	ignore: [
 		// Prevent contrast ratio error on absolutely positioned elements
 		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',

--- a/config/configMobileA11y.js
+++ b/config/configMobileA11y.js
@@ -15,7 +15,7 @@ const testDefaults = {
 	],
 	includeWarnings: true,
 	includeNotices: true,
-	hideElements: '#content',
+	hideElements: '.mw-body-content',
 	ignore: [
 		// Prevent contrast ratio error on absolutely positioned elements
 		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',

--- a/config/configMobileA11y.js
+++ b/config/configMobileA11y.js
@@ -15,7 +15,7 @@ const testDefaults = {
 	],
 	includeWarnings: true,
 	includeNotices: true,
-	hideElements: '#bodyContent',
+	hideElements: '#content',
 	ignore: [
 		// Prevent contrast ratio error on absolutely positioned elements
 		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',

--- a/config/configMobileA11y.js
+++ b/config/configMobileA11y.js
@@ -15,6 +15,7 @@ const testDefaults = {
 	],
 	includeWarnings: true,
 	includeNotices: true,
+	hideElements: '#bodyContent',
 	ignore: [
 		// Prevent contrast ratio error on absolutely positioned elements
 		'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',


### PR DESCRIPTION
Updates to the test page content has introduced new accessibility errors. This PR ignores the user generated content from accessibility tests to focus on testing the skin UI.