### PR TITLE
Reduce timeout from 3 minutes to 0.5 minutes

### DIFF
--- a/config/configCommon.js
+++ b/config/configCommon.js
@@ -5,6 +5,7 @@ module.exports = {
 	engine: 'puppeteer',
 	engineOptions: {
 		headless: 'new',
+		protocolTimeout: 30000,
 		args: [
 			'--no-sandbox',
 			'--disable-setuid-sandbox',


### PR DESCRIPTION
Priority group 3 was taking an extreme amount of time due to some selector churn (iirc) causing a number of timeouts, which had been set to [3 minutes](https://github.com/puppeteer/puppeteer/blob/df731f1dbbb6af4697c9cc9ccdd709d0972fd622/docs/api/puppeteer.browserconnectoptions.protocoltimeout.md) due to puppeteer's BrowserConnectOptions.protocolTimeout using its default value
