### PR TITLE
Fix push action fail on screenshot comparison fail

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,5 +28,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         SCENARIO_FILTER: "Skip all scenarios"
+        NONINTERACTIVE: 1
       run: |
         script -e -c "./pixel.js runAll --priority 3"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,8 +14,6 @@ jobs:
     name: Lint, test, and run visual regression tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      CLONE_DEPTH: 1
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,4 +31,4 @@ jobs:
       env:
         SCENARIO_FILTER: "Skip all scenarios"
       run: |
-        script -e -c "./pixel.js reference && ./pixel.js test"
+        script -e -c "./pixel.js runAll --priority 3"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,5 +28,7 @@ jobs:
       run: npm ci
     - name: Run visual regression
       shell: 'script -q -e -c "bash {0}"'
+      env:
+        SCENARIO_FILTER: "Skip all scenarios"
       run: |
         script -e -c "./pixel.js reference && ./pixel.js test"


### PR DESCRIPTION
No need for push.yml action to actually take screenshots

- add a SCENARIO_FILTER so config runs kicked off by push.yml skip all scenarios (confirmed it still catches syntax and runtime errors)
- added NONINTERACTIVE flag so Pixel doesn't try to open a url
- run priority group 3 so all configs get exercised instead of just desktop config