### PR TITLE
Login cookie fix

### DIFF
--- a/src/engine-scripts/puppet/loadCookies.js
+++ b/src/engine-scripts/puppet/loadCookies.js
@@ -12,7 +12,7 @@ module.exports = async ( page, username ) => {
 	}
 	const cookies = strippedCookies.map( ( cookie ) => {
 		return {
-			domain: 'localhost',
+			domain: 'mediawiki-web',
 			...cookie
 		};
 	} );


### PR DESCRIPTION
When Backstop runs its container name is the domain we need to use to set the cookie