### PR TITLE
Add reverse proxy so we can view mediawiki pages from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - pixel_network
   mediawiki-web:
     image: docker-registry.wikimedia.org/dev/buster-apache2:2.0.0-s1
-    ports:
-      - "${PIXEL_MW_DOCKER_PORT}:8080"
+    expose:
+      - "${PIXEL_MW_DOCKER_PORT}"
     env_file:
       - .env
     environment:
@@ -136,3 +136,14 @@ services:
     working_dir: /pixel/report
     networks:
       - pixel_network
+
+  nginx-proxy:
+      image: nginx:alpine
+      ports:
+        - "${PIXEL_MW_DOCKER_PORT}:80"
+      volumes:
+        - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      depends_on:
+        - mediawiki-web
+      networks:
+        - pixel_network

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        server_name localhost;
+
+        location / {
+            proxy_pass http://mediawiki-web:8080;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Rewrite absolute redirects
+            proxy_redirect http://mediawiki-web:8080/ http://$http_host/;
+            
+            # Rewrite relative redirects
+            proxy_redirect / http://$http_host/;
+        }
+    }
+}


### PR DESCRIPTION
Adds extremely lightweight reverse proxy server

Lets us load pages from the host again after [switching](https://github.com/wikimedia/pixel/commit/08c70a399cd2226bc9cbdbc08c3b362e3aa7b411) to using isolated Docker network