### PR TITLE
Add slight delay between group runs

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -472,6 +472,7 @@ Running regression group "${groupName}"
 						console.log( 'Error occurred' );
 						console.error( e );
 					}
+					await new Promise(resolve => setTimeout(resolve, 5000));
 				} else {
 					console.log( `*************************
 Skipping group "${groupName}" due to priority.


### PR DESCRIPTION
I suspect there being no delay between group runs may have something to do with an issue which occasionally causes the group's report page to not be written properly 