### PR TITLE
Clear desktop dev test cases

### DIFF
--- a/config/configDesktopDev.js
+++ b/config/configDesktopDev.js
@@ -5,12 +5,6 @@ const configDesktop = require( './configDesktop.js' );
  * Modified configuration that outputs to a different directory.
  */
 module.exports = Object.assign( {}, configDesktop, {
-	scenarios: configDesktop.scenarios.map(
-		( scenario ) => utils.addFeatureFlagQueryStringsToScenario( scenario, {
-			vectorclientpreferences: '1',
-			vectorcustomfontsize: '1',
-			vectornightmode: '1'
-		} )
-	),
+	scenarios: [],
 	paths: utils.makePaths( 'desktop-dev' )
 } );


### PR DESCRIPTION
Now dark mode is shipped there is no need for this job. Keeping it empty in anticipation of future usage.