### PR TITLE
Add unique id to configuration.

### DIFF
--- a/config/configCampaignEvents.js
+++ b/config/configCampaignEvents.js
@@ -64,6 +64,7 @@ const scenarios = tests.map( ( test ) => {
 
 module.exports = {
 	...configCommon,
+	id: 'campaign-events',
 	onBeforeScript: 'puppet/onBefore.js',
 	onReadyScript: 'puppet/onReady.js',
 	viewports: [

--- a/config/configCodex.js
+++ b/config/configCodex.js
@@ -167,6 +167,7 @@ const scenarios = components.flatMap( ( componentData ) => {
 
 module.exports = {
 	...configCommon,
+	id: 'codex',
 	onReadyScript: 'puppet/onReady-codex.js',
 	viewports: [
 		VIEWPORT_PHONE,

--- a/config/configDesktop.js
+++ b/config/configDesktop.js
@@ -272,6 +272,7 @@ const scenarios = tests.map( ( test ) => {
 
 module.exports = {
 	...configCommon,
+	id: 'desktop',
 	onBeforeScript: 'puppet/onBefore.js',
 	onReadyScript: 'puppet/onReady.js',
 	viewports: [

--- a/config/configEcho.js
+++ b/config/configEcho.js
@@ -126,6 +126,7 @@ const makeMobileAndDesktopScenarios = ( tests ) => {
 const scenarios = makeMobileAndDesktopScenarios( baseScenarios );
 
 module.exports = Object.assign( {}, configDesktop, {
+	id: 'echo',
 	scenarios,
 	paths: utils.makePaths( 'echo' )
 } );

--- a/config/configLogin.js
+++ b/config/configLogin.js
@@ -40,6 +40,7 @@ const scenarios = utils.makeScenariosForSkins( [
 
 module.exports = {
 	...configCommon,
+	id: 'login',
 	onBeforeScript: 'puppet/onBefore.js',
 	onReadyScript: 'puppet/onReady.js',
 	viewports: [

--- a/config/configMobile.js
+++ b/config/configMobile.js
@@ -129,6 +129,7 @@ const scenarios = tests.map( ( test ) => {
 } );
 
 module.exports = Object.assign( {}, configDesktop, {
+	id: 'mobile',
 	scenarios,
 	paths: utils.makePaths( 'mobile' )
 } );

--- a/config/configWebMaintained.js
+++ b/config/configWebMaintained.js
@@ -64,6 +64,7 @@ const nearbyScenarios = utils.makeScenariosForSkins(
 );
 
 module.exports = Object.assign( {}, configDesktop, {
+	id: 'web-maintained',
 	scenarios: skinScenarios.concat( quickSurveyScenarios ).concat(
 		nearbyScenarios
 	),

--- a/config/configWikiLambda.js
+++ b/config/configWikiLambda.js
@@ -70,6 +70,7 @@ const scenarios = tests.map( ( test ) => {
 
 module.exports = {
 	...configCommon,
+	id: 'wikilambda',
 	onBeforeScript: 'puppet/onBefore.js',
 	onReadyScript: 'puppet/onReady.js',
 	viewports: [


### PR DESCRIPTION
The id is used in the report.json files and before this change all files have the same id inherited from the common config (_Mediawiki_).

By adding a unique id, we can use the report.json files directly and send metrics to our time series database.