### PR TITLE
Reduce false positives in QuickSurvey and Nearby Pixel jobs

### DIFF
--- a/config/configWebMaintained.js
+++ b/config/configWebMaintained.js
@@ -19,7 +19,7 @@ const quickSurveyScenarios = utils.makeScenariosForSkins(
 			query: {
 				quicksurvey: 'external example survey'
 			},
-			selectors: [ '.ext-quick-survey-panel .survey-content' ]
+			selectors: [ '.ext-quick-survey-panel' ]
 		},
 		{
 			label: 'QuickSurvey with single answer',
@@ -28,7 +28,7 @@ const quickSurveyScenarios = utils.makeScenariosForSkins(
 			query: {
 				quicksurvey: 'internal example survey'
 			},
-			selectors: [ '.ext-quick-survey-panel .survey-content' ]
+			selectors: [ '.ext-quick-survey-panel' ]
 		},
 		{
 			label: 'QuickSurvey with multiple answers',
@@ -37,7 +37,7 @@ const quickSurveyScenarios = utils.makeScenariosForSkins(
 			query: {
 				quicksurvey: 'internal multi answer example survey'
 			},
-			selectors: [ '.ext-quick-survey-panel .survey-content' ]
+			selectors: [ '.ext-quick-survey-panel' ]
 		}
 	],
 	[ 'vector', 'vector-2022', 'minerva' ]
@@ -56,7 +56,7 @@ const nearbyScenarios = utils.makeScenariosForSkins(
 			label: 'Nearby error state',
 			path: '/wiki/Special:Nearby',
 			hash: '#/coord/0,-700',
-			hashtags: [ '#nearby' ],
+			hashtags: [ '#nearby', ' #nearby-error' ],
 			selectors: [ '#mw-content-text' ]
 		}
 	],

--- a/src/engine-scripts/puppet/jsReady.js
+++ b/src/engine-scripts/puppet/jsReady.js
@@ -28,6 +28,14 @@ module.exports = async ( page, hashtags ) => {
 	await moduleReady( page, getSkinModuleFromHashtags( hashtags ) );
 	if ( hashtags.includes( '#quicksurvey' ) ) {
 		await moduleReady( page, 'ext.quicksurveys.lib.vue' );
+		// Wait for the survey close button to render.
+		await page.waitForSelector( '.survey-close-button' );
+	}
+	if ( hashtags.includes( '#nearby' ) ) {
+		await moduleReady( page, 'ext.nearby.scripts' );
+		if ( !hashtags.includes( '#nearby-error' ) ) {
+			await page.waitForSelector( '.mw-vue-nearby .mw-vue-page-list__card-proximity' );
+		}
 	}
 	await page.evaluate( () => {
 		// Wait until the next frame before resolving. collapsibleTabs.js in Vector


### PR DESCRIPTION
The snapshot is often taken before the quick survey/Nearby renders, since the survey requires Vue to load and shows an ajax loader.

I'm hoping these changes will improve reliability of https://pixel.wmcloud.org/reports/web-maintained/index.html