### PR TITLE
Add regression tests for history pages

### DIFF
--- a/config/configMobile.js
+++ b/config/configMobile.js
@@ -12,6 +12,14 @@ const tests = [
 		path: '/wiki/Talk:Test'
 	},
 	{
+		label: 'Test history page in AMC mode (#minerva)',
+		path: '/wiki/Test?action=history'
+	},
+	{
+		label: 'Test history page (#minerva #mobile)',
+		path: '/wiki/Test?action=history'
+	},
+	{
 		label: 'Test (#minerva #mobile)',
 		path: '/wiki/Test'
 	},


### PR DESCRIPTION
This will provide coverage for Special:RecentChanges, Special:Contributions and similar pages which share styling.

This would have caught the issue in T335932.
I intentionally do not test Special:RecentChanges as this would require updating the database on every page load to ensure this has diffs.