### PR TITLE
Add longer wait time for the database to become availible.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,8 @@ services:
       - ./src/seedDb.sh:/docker-entrypoint-initdb.d/seedDb.sh
     healthcheck:
       test: [ CMD, mysql, my_wiki, -e, status ]
-      interval: 1s
-      timeout: 5s
+      interval: 5s
+      timeout: 10s
       retries: 20
     networks:
       - pixel_network


### PR DESCRIPTION
On the prodcution server the database sometimes do not start in time and then everything fails. However after a while the database is up but then all other services was closed down.

https://phabricator.wikimedia.org/T385882