### PR TITLE
Remove Growth Experiments

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -162,7 +162,6 @@ wfLoadExtension( 'Thanks' );
 wfLoadExtension( 'UniversalLanguageSelector' );
 wfLoadExtension( 'VisualEditor' );
 wfLoadExtension( 'CommunityConfiguration' );
-wfLoadExtension( 'GrowthExperiments' );
 wfLoadExtension( 'VueTest' );
 if ( getenv('ENABLE_WIKILAMBDA') == 'true' ) {
 	wfLoadExtension( 'WikiLambda' );

--- a/config/configMobile.js
+++ b/config/configMobile.js
@@ -92,7 +92,7 @@ const tests = [
 		path: '/wiki/Page_issue'
 	},
 	{
-		label: 'Special:Homepage overlay (#minerva #mobile #logged-in #click-edit-suggestions)',
+		label: 'Special:Homepage overlay (#minerva #mobile #logged-in)',
 		path: '/wiki/Special:Homepage'
 	},
 	{

--- a/repositories.json
+++ b/repositories.json
@@ -23,9 +23,6 @@
 	"mediawiki/extensions/CommunityConfiguration": {
 		"path": "extensions/CommunityConfiguration"
 	},
-	"mediawiki/extensions/GrowthExperiments": {
-		"path": "extensions/GrowthExperiments"
-	},
 	"mediawiki/extensions/Linter": {
 		"path": "extensions/Linter"
 	},

--- a/src/engine-scripts/puppet/onReady.js
+++ b/src/engine-scripts/puppet/onReady.js
@@ -57,9 +57,6 @@ module.exports = async ( page, scenario ) => {
 		if ( hashtags.includes( '#click-redlink' ) ) {
 			await clickBtn( page, 'a.new' );
 		}
-		if ( hashtags.includes( '#click-edit-suggestions' ) ) {
-			await clickBtn( page, '.growthexperiments-homepage-module-header-nav-icon' );
-		}
 		if ( hashtags.includes( '#click-reference' ) ) {
 			await clickBtn( page, '#cite_ref-1 a' );
 		}


### PR DESCRIPTION
G.E. now requires Cirrus Search, but Pixel is far
too convoluted to add Cirrus cleanly right now

After refactoring Pixel to be loosely coupled to
Mediawiki instance we can circle back and re-add
it